### PR TITLE
feat: flor pública as first-session aha (P0)

### DIFF
--- a/apps/web/app/api/onboarding/complete/route.ts
+++ b/apps/web/app/api/onboarding/complete/route.ts
@@ -101,8 +101,16 @@ export async function POST(req: Request) {
     );
     const snapshot = flowerSnapshot(created, refs);
     const kinsEarned = created.length * skillDelta;
+    const petalIds = [...new Set(created.map((s) => s.petalId))];
 
-    return { profile, skills: created, snapshot, kinsEarned };
+    return {
+      userId: session.username,
+      petalIds,
+      profile,
+      skills: created,
+      snapshot,
+      kinsEarned,
+    };
   });
 
   return NextResponse.json(result);

--- a/apps/web/app/api/references/route.ts
+++ b/apps/web/app/api/references/route.ts
@@ -22,60 +22,86 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
   }
 
-  const receipt = await attestAction(
-    {
-      platformUrl: process.env.CERTEXI_PLATFORM_URL || '',
-      allowStub: flag('ECO_ALLOW_PROOF_STUB'),
-    },
-    {
-      kind: 'skill_reference',
-      subjectUserId: body.toUserId,
-      payload: {
-        skillId: body.skillId,
-        fromUserId: session.username,
-        grade: body.grade ?? 3,
+  if (body.toUserId === session.username) {
+    return NextResponse.json({ error: 'self_attestation' }, { status: 400 });
+  }
+
+  try {
+    const receipt = await attestAction(
+      {
+        platformUrl: process.env.CERTEXI_PLATFORM_URL || '',
+        allowStub: flag('ECO_ALLOW_PROOF_STUB'),
       },
-    },
-  );
+      {
+        kind: 'skill_reference',
+        subjectUserId: body.toUserId,
+        payload: {
+          skillId: body.skillId,
+          fromUserId: session.username,
+          grade: body.grade ?? 3,
+        },
+      },
+    );
 
-  const ref = await withStore((db) => {
-    const skill = db.skills.find((s) => s.id === body.skillId);
-    if (!skill) {
-      throw new Error('skill_not_found');
-    }
-    const row = {
-      id: uid('ref'),
-      skillId: body.skillId!,
-      fromUserId: session.username,
-      toUserId: body.toUserId!,
-      grade: clampSkillLevel(body.grade ?? 3),
-      note: body.note,
-      proofId: receipt.id,
-      createdAt: new Date().toISOString(),
-    };
-    db.skillReferences.push(row);
-    db.proofs.push({
-      id: receipt.id,
-      kind: receipt.kind,
-      subjectUserId: receipt.subjectUserId,
-      relatedId: row.id,
-      stub: receipt.stub,
-      payload: receipt.payload,
-      createdAt: receipt.createdAt,
-    });
-    db.kins.push({
-      id: uid('kins'),
-      userId: body.toUserId!,
-      type: 'reference',
-      delta: earnDelta('reference'),
-      relatedId: row.id,
-      createdAt: row.createdAt,
-    });
-    return row;
-  });
+    const ref = await withStore((db) => {
+      const skill = db.skills.find((s) => s.id === body.skillId);
+      if (!skill) {
+        throw new Error('skill_not_found');
+      }
+      if (skill.userId !== body.toUserId) {
+        throw new Error('skill_owner_mismatch');
+      }
+      const dup = db.skillReferences.find(
+        (r) =>
+          r.fromUserId === session.username && r.skillId === body.skillId,
+      );
+      if (dup) {
+        throw new Error('duplicate_reference');
+      }
 
-  return NextResponse.json({
-    reference: ref,
-    proof: { id: receipt.id, stub: receipt.stub },
-  });
+      const row = {
+        id: uid('ref'),
+        skillId: body.skillId!,
+        fromUserId: session.username,
+        toUserId: body.toUserId!,
+        grade: clampSkillLevel(body.grade ?? 3),
+        note: body.note ? String(body.note) : undefined,
+        proofId: receipt.id,
+        createdAt: new Date().toISOString(),
+      };
+      db.skillReferences.push(row);
+      db.proofs.push({
+        id: receipt.id,
+        kind: receipt.kind,
+        subjectUserId: receipt.subjectUserId,
+        relatedId: row.id,
+        stub: receipt.stub,
+        payload: receipt.payload,
+        createdAt: receipt.createdAt,
+      });
+      db.kins.push({
+        id: uid('kins'),
+        userId: body.toUserId!,
+        type: 'reference',
+        delta: earnDelta('reference'),
+        relatedId: row.id,
+        createdAt: row.createdAt,
+      });
+      return row;
+    });
+
+    return NextResponse.json({
+      reference: ref,
+      proof: { id: receipt.id, stub: receipt.stub },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'error';
+    const status =
+      message === 'skill_not_found' ||
+      message === 'skill_owner_mismatch' ||
+      message === 'duplicate_reference'
+        ? 400
+        : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -664,3 +664,64 @@ label {
   font-size: 0.9rem;
   font-weight: 600;
 }
+
+.copy-link-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.copy-toast {
+  font-size: 0.8rem;
+  color: var(--green-bright);
+  animation: onboard-in var(--duration-ui) var(--ease-out) both;
+}
+
+.meet-handoff-banner {
+  margin: 0.85rem 0 0;
+  padding: 0.65rem 0.85rem;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--green-bright) 35%, var(--line));
+  background: color-mix(in srgb, var(--green) 14%, var(--bg-elev));
+  color: var(--ink);
+  font-size: 0.9rem;
+}
+
+.home-hero {
+  padding: 2rem 0 1rem;
+  max-width: 36rem;
+}
+
+.home-hero .brand-mark {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+
+.home-hero .brand-mark em {
+  font-style: normal;
+  color: var(--green-bright);
+}
+
+.home-hero .promise {
+  font-size: clamp(1.1rem, 2.2vw, 1.35rem);
+  line-height: 1.4;
+  color: var(--ink);
+  margin: 0 0 0.65rem;
+}
+
+.home-support {
+  margin: 0;
+  max-width: 28rem;
+  font-size: 0.95rem;
+}
+
+.home-dev {
+  margin-top: 2rem;
+  opacity: 0.85;
+}

--- a/apps/web/app/meet/page.tsx
+++ b/apps/web/app/meet/page.tsx
@@ -1,51 +1,38 @@
-import { flowerSnapshot, getPetal } from '@ecologikal/domain';
+import { isPetalId, type PetalId } from '@ecologikal/domain';
+import { getSession } from '@/lib/auth';
 import { readStore } from '@/lib/store';
-import { FlowerViz } from '@/components/FlowerViz';
+import { MeetDirectory } from '@/components/MeetDirectory';
 
-export default async function MeetPage() {
+type Props = {
+  searchParams: Promise<{ petal?: string; from?: string }>;
+};
+
+export default async function MeetPage({ searchParams }: Props) {
+  const session = await getSession();
+  const q = await searchParams;
+  const petalNum = Number(q.petal);
+  const initialPetal: PetalId | null = isPetalId(petalNum) ? petalNum : null;
+  const fromOnboarding = q.from === 'onboarding';
+
   const db = await readStore();
-  const guests = db.profiles.filter((p) => p.accountClass !== 'admin');
+  const guests = db.profiles
+    .filter((p) => p.accountClass !== 'admin')
+    .map((p) => ({
+      userId: p.userId,
+      displayName: p.displayName,
+      accountClass: p.accountClass,
+      skills: db.skills.filter((s) => s.userId === p.userId),
+      refs: db.skillReferences.filter((r) => r.toUserId === p.userId),
+    }));
 
   return (
-    <main className="stack">
-      <section className="card">
-        <h1>Conoce</h1>
-        <p className="muted">
-          Econautas por flor de skills — reputación visual, no keyword spam.
-        </p>
-      </section>
-
-      <section className="grid">
-        {guests.length === 0 ? (
-          <div className="card">
-            <p className="muted">Sin perfiles aún.</p>
-          </div>
-        ) : (
-          guests.map((p) => {
-            const skills = db.skills.filter((s) => s.userId === p.userId);
-            const refs = db.skillReferences.filter(
-              (r) => r.toUserId === p.userId,
-            );
-            const snap = flowerSnapshot(skills, refs);
-            return (
-              <article key={p.userId} className="card">
-                <h2>{p.displayName}</h2>
-                <p className="muted">
-                  <span className="badge">{p.accountClass}</span>
-                </p>
-                <FlowerViz snapshot={snap} />
-                <ul>
-                  {skills.slice(0, 5).map((s) => (
-                    <li key={s.id}>
-                      {s.name} · {getPetal(s.petalId).nameEs}
-                    </li>
-                  ))}
-                </ul>
-              </article>
-            );
-          })
-        )}
-      </section>
+    <main>
+      <MeetDirectory
+        guests={guests}
+        sessionUserId={session?.username ?? null}
+        initialPetal={initialPetal}
+        fromOnboarding={fromOnboarding}
+      />
     </main>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,77 +5,40 @@ import { vintageUrl } from '@/lib/urls';
 
 export default function HomePage() {
   const vintage = vintageUrl('/');
-  const allowSeed =
+  const allowDev =
     process.env.ECO_ALLOW_DEV_LOGIN === 'true' ||
     process.env.ECO_ALLOW_PROOF_STUB === 'true';
 
   return (
     <main>
-      <section className="card">
-        <h1>
-          Red <span style={{ color: 'var(--green-bright)' }}>Eco</span> +{' '}
-          <span style={{ color: '#7eb6ff' }}>Social</span>
-          <span className="badge" style={{ marginLeft: '0.6rem' }}>
-            revival v2
-          </span>
-        </h1>
-        <p className="muted" style={{ maxWidth: '40rem' }}>
-          Dual-stack: esta UI Next.js coexiste con el PHP vintage. Certexi OS
-          aporta SSO y prueba; Eco Nextcloud hosts/guests.
+      <section className="home-hero">
+        <p className="brand-mark">
+          Eco<em>logikal</em>
         </p>
-        <div className="row" style={{ marginTop: '1.25rem' }}>
+        <p className="promise">
+          Tu flor de habilidades es tu reputación en la red regenerativa.
+        </p>
+        <p className="muted home-support">
+          Declara pétalos, gana KINS, y conoce econautas por lo que saben hacer.
+        </p>
+        <div className="row" style={{ marginTop: '1.5rem' }}>
           <Link className="btn" href="/login">
-            Entrar (v2)
+            Empezar mi flor
           </Link>
-          <a className="btn secondary" href={vintage}>
-            Abrir Vintage PHP
-          </a>
-          <Link className="btn secondary" href="/travel">
-            Viaja
+          <Link className="btn secondary" href="/meet">
+            Conoce
           </Link>
-          {allowSeed ? <SeedDemoButton /> : null}
+        </div>
+        <div className="pillars" style={{ marginTop: '1.25rem' }}>
+          {PILLARS.map((p) => (
+            <Link key={p.id} href={p.href}>
+              {p.labelEs}
+            </Link>
+          ))}
         </div>
       </section>
 
-      <section className="grid">
-        <article className="card">
-          <h2>Vintage</h2>
-          <p className="muted">
-            PHP 2011–2012 en{' '}
-            <code>{vintage}</code> (gateway <code>:8090/</code> o directo{' '}
-            <code>:8082</code>).
-          </p>
-          <ul>
-            <li>
-              <a href={vintageUrl('/learnfeed.php')}>Aprende</a>
-            </li>
-            <li>
-              <a href={vintageUrl('/meetfeed.php')}>Conoce</a>
-            </li>
-            <li>
-              <a href={vintageUrl('/ecocentersdir.php')}>Viaja</a>
-            </li>
-            <li>
-              <a href={vintageUrl('/discoverfeed.php')}>Descubre</a>
-            </li>
-          </ul>
-        </article>
-        <article className="card">
-          <h2>Revival v2</h2>
-          <p className="muted">
-            Pilares con store local + bridge Certexi. Misma IA, nuevo runtime.
-          </p>
-          <div className="pillars" style={{ marginTop: '0.5rem' }}>
-            {PILLARS.map((p) => (
-              <Link key={p.id} href={p.href}>
-                {p.labelEs}
-              </Link>
-            ))}
-          </div>
-        </article>
-      </section>
-
-      <section className="card">
+      <section className="card" style={{ marginTop: '2rem' }}>
         <h2>Siete pétalos</h2>
         <div className="row" style={{ marginTop: '0.75rem' }}>
           {PETALS.map((petal) => (
@@ -89,6 +52,21 @@ export default function HomePage() {
           ))}
         </div>
       </section>
+
+      {allowDev ? (
+        <section className="card home-dev">
+          <h2>Desarrollo</h2>
+          <p className="muted">
+            Dual-stack y semillas — solo con flags de demo.
+          </p>
+          <div className="row" style={{ marginTop: '0.75rem' }}>
+            <a className="btn secondary" href={vintage}>
+              Vintage PHP
+            </a>
+            <SeedDemoButton />
+          </div>
+        </section>
+      ) : null}
     </main>
   );
 }

--- a/apps/web/app/profile/[userId]/page.tsx
+++ b/apps/web/app/profile/[userId]/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  flowerSnapshot,
+  balanceFor,
+  getPetal,
+  PETALS,
+} from '@ecologikal/domain';
+import { getSession } from '@/lib/auth';
+import { readStore } from '@/lib/store';
+import { FlowerViz } from '@/components/FlowerViz';
+import { AddReferenceForm } from '@/components/ClientForms';
+import { CopyLinkButton } from '@/components/CopyLinkButton';
+
+type Props = {
+  params: Promise<{ userId: string }>;
+};
+
+async function loadProfile(userId: string) {
+  const db = await readStore();
+  const profile = db.profiles.find((p) => p.userId === userId);
+  if (!profile) return null;
+  const skills = db.skills.filter((s) => s.userId === userId);
+  const refs = db.skillReferences.filter((r) => r.toUserId === userId);
+  return { db, profile, skills, refs };
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { userId: rawId } = await params;
+  const userId = decodeURIComponent(rawId);
+  const data = await loadProfile(userId);
+  if (!data) {
+    return { title: 'Flor · Ecologikal' };
+  }
+  const petalNames = [
+    ...new Set(data.skills.map((s) => getPetal(s.petalId).nameEs)),
+  ];
+  const petalLine =
+    petalNames.length > 0
+      ? petalNames.slice(0, 3).join(', ')
+      : PETALS.map((p) => p.nameEs).slice(0, 2).join(', ');
+  const title = `${data.profile.displayName} · flor Ecologikal`;
+  const description = `${data.profile.displayName} crece en ${petalLine}. Reputación por habilidades, no por likes.`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+    },
+  };
+}
+
+export default async function PublicProfilePage({ params }: Props) {
+  const { userId: rawId } = await params;
+  const userId = decodeURIComponent(rawId);
+  const session = await getSession();
+  const data = await loadProfile(userId);
+  if (!data) notFound();
+
+  const { db, profile, skills, refs } = data;
+  const snapshot = flowerSnapshot(skills, refs);
+  const kins = balanceFor(db.kins, userId);
+  const proofs = db.proofs.filter((p) => p.subjectUserId === userId);
+  const isSelf = session?.username === userId;
+  const canAttest = Boolean(session && !isSelf && skills.length > 0);
+  const publicPath = `/profile/${encodeURIComponent(userId)}`;
+
+  return (
+    <main className="stack">
+      <section className="card">
+        <h1>{profile.displayName}</h1>
+        <p className="muted">
+          <span className="badge">{profile.accountClass}</span> · @{userId} ·
+          KINS <strong>{kins}</strong>
+          {isSelf ? (
+            <>
+              {' · '}
+              <Link href="/profile">Editar mi perfil</Link>
+            </>
+          ) : null}
+        </p>
+        {profile.bio ? <p>{profile.bio}</p> : null}
+        {isSelf ? (
+          <div className="row" style={{ marginTop: '0.75rem' }}>
+            <CopyLinkButton url={publicPath} className="btn secondary" />
+            <span className="muted" style={{ fontSize: '0.85rem' }}>
+              Comparte tu flor
+            </span>
+          </div>
+        ) : null}
+        <FlowerViz
+          snapshot={snapshot}
+          skills={skills}
+          refs={refs}
+          proofs={proofs.map((p) => ({ id: p.id, stub: p.stub }))}
+        />
+      </section>
+
+      <section className="card">
+        <h2>Skills</h2>
+        {skills.length === 0 ? (
+          <p className="muted">Sin skills declaradas.</p>
+        ) : (
+          <ul>
+            {skills.map((s) => (
+              <li key={s.id}>
+                {s.name} · {getPetal(s.petalId).nameEs} · nivel {s.level}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>Referencias</h2>
+        {refs.length === 0 ? (
+          <p className="muted">Sin referencias aún.</p>
+        ) : (
+          <ul>
+            {refs.map((r) => {
+              const proof = proofs.find((p) => p.id === r.proofId);
+              const skill = skills.find((s) => s.id === r.skillId);
+              return (
+                <li key={r.id}>
+                  {skill?.name ?? r.skillId} · de {r.fromUserId} · grado{' '}
+                  {r.grade}
+                  {proof ? (
+                    <span className="badge verified">
+                      {proof.stub ? 'proof stub' : 'verified'} {proof.id}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {canAttest ? (
+        <section className="card" id="attest">
+          <h2>Atestar skill</h2>
+          <p className="muted">
+            Deja una referencia peer-attested. Suma +3 KINS a{' '}
+            {profile.displayName}.
+          </p>
+          <AddReferenceForm
+            skills={skills.map((s) => ({
+              id: s.id,
+              name: s.name,
+              userId: s.userId,
+            }))}
+            toUserId={userId}
+          />
+        </section>
+      ) : null}
+
+      {!session ? (
+        <section className="card">
+          <h2>¿Te gusta esta flor?</h2>
+          <p className="muted">
+            Entra y dibuja la tuya — reputación por lo que sabes hacer.
+          </p>
+          <Link className="btn" href="/login">
+            Entrar y crear mi flor
+          </Link>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { flowerSnapshot, balanceFor, getPetal } from '@ecologikal/domain';
 import { getSession } from '@/lib/auth';
@@ -23,8 +24,17 @@ export default async function ProfilePage() {
         <p className="muted">
           Clase <span className="badge">{session.accountClass}</span> · KINS{' '}
           <strong>{kins}</strong>
+          {' · '}
+          <Link href={`/profile/${encodeURIComponent(session.username)}`}>
+            Ver perfil público
+          </Link>
         </p>
-        <FlowerViz snapshot={snapshot} />
+        <FlowerViz
+          snapshot={snapshot}
+          skills={skills}
+          refs={refs}
+          proofs={proofs.map((p) => ({ id: p.id, stub: p.stub }))}
+        />
       </section>
 
       <section className="grid">

--- a/apps/web/components/ClientForms.tsx
+++ b/apps/web/components/ClientForms.tsx
@@ -121,14 +121,18 @@ export function AddSkillForm() {
 
 export function AddReferenceForm({
   skills,
+  toUserId,
 }: {
   skills: Array<{ id: string; name: string; userId: string }>;
+  /** When set, all skills belong to this user (public profile). */
+  toUserId?: string;
 }) {
   const router = useRouter();
   const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   if (skills.length === 0) {
-    return <p className="muted">No hay skills de otros usuarios para atestar.</p>;
+    return <p className="muted">No hay skills para atestar.</p>;
   }
 
   return (
@@ -136,21 +140,27 @@ export function AddReferenceForm({
       className="stack"
       onSubmit={async (e) => {
         e.preventDefault();
+        setError(null);
+        setMsg(null);
         const fd = new FormData(e.currentTarget);
         const skillId = String(fd.get('skillId'));
         const skill = skills.find((s) => s.id === skillId);
-        const data = await postJson('/api/references', {
-          skillId,
-          toUserId: skill?.userId,
-          grade: Number(fd.get('grade')),
-          note: fd.get('note'),
-        });
-        setMsg(
-          data.proof?.stub
-            ? `Atestado (proof stub ${data.proof.id})`
-            : `Atestado verificado ${data.proof?.id}`,
-        );
-        router.refresh();
+        try {
+          const data = await postJson('/api/references', {
+            skillId,
+            toUserId: toUserId ?? skill?.userId,
+            grade: Number(fd.get('grade')),
+            note: fd.get('note'),
+          });
+          setMsg(
+            data.proof?.stub
+              ? `Atestado (proof stub ${data.proof.id})`
+              : `Atestado verificado ${data.proof?.id}`,
+          );
+          router.refresh();
+        } catch (err) {
+          setError(err instanceof Error ? err.message : 'error');
+        }
       }}
     >
       <label>
@@ -158,7 +168,7 @@ export function AddReferenceForm({
         <select name="skillId">
           {skills.map((s) => (
             <option key={s.id} value={s.id}>
-              {s.name} ({s.userId})
+              {toUserId ? s.name : `${s.name} (${s.userId})`}
             </option>
           ))}
         </select>
@@ -175,6 +185,7 @@ export function AddReferenceForm({
         Atestar (+ proof Certexi)
       </button>
       {msg ? <p className="badge verified">{msg}</p> : null}
+      {error ? <p className="muted">{error}</p> : null}
     </form>
   );
 }

--- a/apps/web/components/CopyLinkButton.tsx
+++ b/apps/web/components/CopyLinkButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { LinkSimple } from '@phosphor-icons/react';
+
+type Props = {
+  /** Absolute or path URL to copy */
+  url: string;
+  label?: string;
+  className?: string;
+  toast?: string;
+};
+
+/**
+ * Clipboard copy with brief confirmation — shared by reveal + public profile.
+ */
+export function CopyLinkButton({
+  url,
+  label = 'Copiar enlace',
+  className = 'btn',
+  toast = 'Enlace copiado — compártelo con quien te conoce',
+}: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function onCopy() {
+    const absolute =
+      url.startsWith('http') || typeof window === 'undefined'
+        ? url
+        : new URL(url, window.location.origin).toString();
+    try {
+      await navigator.clipboard.writeText(absolute);
+    } catch {
+      window.prompt('Copia este enlace:', absolute);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2200);
+  }
+
+  return (
+    <span className="copy-link-wrap">
+      <button
+        type="button"
+        className={className}
+        onClick={() => void onCopy()}
+        aria-live="polite"
+      >
+        <LinkSimple size={16} weight="bold" aria-hidden />
+        {copied ? 'Copiado' : label}
+      </button>
+      {copied ? (
+        <span className="copy-toast" role="status">
+          {toast}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/components/FlowerViz.tsx
+++ b/apps/web/components/FlowerViz.tsx
@@ -1,38 +1,292 @@
-import { PETALS, type FlowerSnapshot } from '@ecologikal/domain';
+'use client';
 
-export function FlowerViz({ snapshot }: { snapshot: FlowerSnapshot }) {
+import { useMemo, useState } from 'react';
+import {
+  PETALS,
+  getPetal,
+  type FlowerSnapshot,
+  type PetalId,
+  type Skill,
+  type SkillReference,
+} from '@ecologikal/domain';
+
+export type FlowerProof = {
+  id: string;
+  stub?: boolean;
+};
+
+type Props = {
+  snapshot: FlowerSnapshot;
+  skills?: Skill[];
+  refs?: SkillReference[];
+  proofs?: FlowerProof[];
+  compact?: boolean;
+  /** When set, petal click calls this instead of opening the panel (meet cards). */
+  onPetalSelect?: (petalId: PetalId) => void;
+};
+
+/**
+ * Polar skill flower — concentric arcs inspired by vintage Raphael viz.
+ * Grade 1–5 maps to arc sweep; click a ring to drill into petal skills.
+ */
+export function FlowerViz({
+  snapshot,
+  skills = [],
+  refs = [],
+  proofs = [],
+  compact = false,
+  onPetalSelect,
+}: Props) {
+  const [selected, setSelected] = useState<PetalId | null>(null);
+  const size = compact ? 160 : 280;
+  const cx = size / 2;
+  const cy = size / 2;
+  const stroke = compact ? 8 : 14;
+  const gap = compact ? 3 : 4;
+  const baseR = compact ? 18 : 28;
+
+  const rings = useMemo(() => {
+    return PETALS.map((petal, i) => {
+      const grade =
+        snapshot.petals.find((p) => p.petalId === petal.id)?.grade ?? 0;
+      const rad = baseR + i * (stroke + gap);
+      const sweep = Math.max(0.001, Math.min(1, grade / 5)) * 359.99;
+      return { petal, grade, rad, sweep };
+    });
+  }, [snapshot, baseR, stroke, gap]);
+
+  const petalSkills = selected
+    ? skills.filter((s) => s.petalId === selected)
+    : [];
+
+  function handlePetal(petalId: PetalId) {
+    if (onPetalSelect) {
+      onPetalSelect(petalId);
+      return;
+    }
+    if (compact) return;
+    setSelected((prev) => (prev === petalId ? null : petalId));
+  }
+
   return (
-    <div>
-      <p className="muted">
+    <div className={`flower-viz${compact ? ' compact' : ''}`}>
+      <p className="muted flower-overall">
         Flor general:{' '}
         <strong style={{ color: 'var(--ink)' }}>
           {snapshot.overall.toFixed(2)}
         </strong>{' '}
         / 5
       </p>
-      <div className="flower" aria-label="Skill flower">
-        {PETALS.map((petal) => {
-          const grade =
-            snapshot.petals.find((p) => p.petalId === petal.id)?.grade ?? 0;
-          const pct = Math.min(100, (grade / 5) * 100);
-          return (
-            <div className="petal-bar" key={petal.id}>
-              <div className="bar">
-                <div
-                  className="fill"
-                  style={{
-                    height: `${pct}%`,
-                    background: petal.color,
-                  }}
+      <div className="flower-chart-row">
+        <svg
+          className="flower-svg"
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          role="img"
+          aria-label="Flor de habilidades"
+        >
+          <circle
+            cx={cx}
+            cy={cy}
+            r={baseR - stroke / 2 - 2}
+            fill="var(--bg)"
+            stroke="var(--line)"
+            strokeWidth={1}
+          />
+          {rings.map(({ petal, grade, rad, sweep }) => {
+            const active = selected === petal.id;
+            const dimTrack = describeArc(cx, cy, rad, 0, 359.99);
+            const dimArc =
+              grade > 0 ? describeArc(cx, cy, rad, 0, sweep) : null;
+            return (
+              <g key={petal.id}>
+                <path
+                  d={dimTrack}
+                  fill="none"
+                  stroke="var(--line)"
+                  strokeWidth={stroke}
+                  strokeLinecap="round"
+                  opacity={0.35}
                 />
-              </div>
-              <small>
-                {petal.id}. {petal.nameEs}
-              </small>
-            </div>
-          );
-        })}
+                {dimArc ? (
+                  <path
+                    d={dimArc}
+                    fill="none"
+                    stroke={petal.color}
+                    strokeWidth={active ? stroke + 3 : stroke}
+                    strokeLinecap="round"
+                    className="flower-arc"
+                    style={{ cursor: 'pointer' }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`${petal.nameEs}, grado ${grade.toFixed(1)} de 5`}
+                    aria-pressed={active}
+                    onClick={() => handlePetal(petal.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handlePetal(petal.id);
+                      }
+                    }}
+                  />
+                ) : (
+                  <path
+                    d={dimTrack}
+                    fill="none"
+                    stroke={petal.color}
+                    strokeWidth={stroke}
+                    strokeLinecap="round"
+                    opacity={0.15}
+                    style={{ cursor: 'pointer' }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`${petal.nameEs}, sin skills`}
+                    onClick={() => handlePetal(petal.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handlePetal(petal.id);
+                      }
+                    }}
+                  />
+                )}
+              </g>
+            );
+          })}
+        </svg>
+        {!compact ? (
+          <ul className="flower-legend">
+            {PETALS.map((p) => {
+              const grade =
+                snapshot.petals.find((x) => x.petalId === p.id)?.grade ?? 0;
+              return (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    className={
+                      selected === p.id ? 'legend-btn on' : 'legend-btn'
+                    }
+                    style={{ borderColor: p.color }}
+                    onClick={() => handlePetal(p.id)}
+                  >
+                    <span
+                      className="swatch"
+                      style={{ background: p.color }}
+                    />
+                    {p.nameEs}
+                    <span className="muted"> {grade.toFixed(1)}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
       </div>
+
+      {!compact && selected ? (
+        <div
+          className="flower-panel"
+          style={{ borderColor: getPetal(selected).color }}
+        >
+          <div className="row" style={{ justifyContent: 'space-between' }}>
+            <h3 style={{ margin: 0, color: getPetal(selected).color }}>
+              {getPetal(selected).nameEs}
+            </h3>
+            <button
+              type="button"
+              className="btn secondary"
+              onClick={() => setSelected(null)}
+            >
+              Cerrar
+            </button>
+          </div>
+          {petalSkills.length === 0 ? (
+            <p className="muted">Sin skills en este pétalo.</p>
+          ) : (
+            <ul className="flower-skill-list">
+              {petalSkills.map((skill) => {
+                const skillRefs = refs.filter((r) => r.skillId === skill.id);
+                const peerAvg =
+                  skillRefs.length === 0
+                    ? null
+                    : skillRefs.reduce((a, r) => a + r.grade, 0) /
+                      skillRefs.length;
+                return (
+                  <li key={skill.id}>
+                    <strong>{skill.name}</strong>
+                    <span className="muted">
+                      {' '}
+                      · declarado {skill.level}
+                      {peerAvg != null
+                        ? ` · peers ${peerAvg.toFixed(1)}`
+                        : ''}
+                    </span>
+                    {skillRefs.length > 0 ? (
+                      <ul className="flower-refs">
+                        {skillRefs.map((r) => {
+                          const proof = proofs.find((p) => p.id === r.proofId);
+                          return (
+                            <li key={r.id}>
+                              de {r.fromUserId} · grado {r.grade}
+                              {r.note ? ` — ${r.note}` : ''}
+                              {proof ? (
+                                <span className="badge verified">
+                                  {proof.stub ? 'proof stub' : 'verified'}{' '}
+                                  {proof.id}
+                                </span>
+                              ) : null}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      ) : null}
     </div>
   );
+}
+
+/** Polar arc path from startAngle to endAngle (degrees, 0 = east, CCW). */
+function describeArc(
+  cx: number,
+  cy: number,
+  r: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const start = polarToCartesian(cx, cy, r, endAngle);
+  const end = polarToCartesian(cx, cy, r, startAngle);
+  const large = endAngle - startAngle <= 180 ? '0' : '1';
+  return [
+    'M',
+    start.x,
+    start.y,
+    'A',
+    r,
+    r,
+    0,
+    large,
+    0,
+    end.x,
+    end.y,
+  ].join(' ');
+}
+
+function polarToCartesian(
+  cx: number,
+  cy: number,
+  r: number,
+  angleDeg: number,
+) {
+  const rad = ((angleDeg - 90) * Math.PI) / 180;
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad),
+  };
 }

--- a/apps/web/components/MeetDirectory.tsx
+++ b/apps/web/components/MeetDirectory.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import {
+  PETALS,
+  flowerSnapshot,
+  getPetal,
+  type PetalId,
+  type Skill,
+  type SkillReference,
+} from '@ecologikal/domain';
+import { FlowerViz } from '@/components/FlowerViz';
+
+export type MeetGuest = {
+  userId: string;
+  displayName: string;
+  accountClass: string;
+  skills: Skill[];
+  refs: SkillReference[];
+};
+
+type Props = {
+  guests: MeetGuest[];
+  sessionUserId?: string | null;
+  /** Prefill from /meet?petal= after onboarding */
+  initialPetal?: PetalId | null;
+  fromOnboarding?: boolean;
+};
+
+export function MeetDirectory({
+  guests,
+  sessionUserId,
+  initialPetal = null,
+  fromOnboarding = false,
+}: Props) {
+  const [petalFilter, setPetalFilter] = useState<PetalId | null>(initialPetal);
+  const [sortMode, setSortMode] = useState<'overall' | 'petal'>(
+    initialPetal != null ? 'petal' : 'overall',
+  );
+
+  const ranked = useMemo(() => {
+    const withSnap = guests.map((g) => {
+      const snap = flowerSnapshot(g.skills, g.refs);
+      const petalGrade =
+        petalFilter == null
+          ? 0
+          : (snap.petals.find((p) => p.petalId === petalFilter)?.grade ?? 0);
+      return { ...g, snap, petalGrade };
+    });
+
+    let filtered = withSnap;
+    if (petalFilter != null) {
+      filtered = withSnap.filter(
+        (g) =>
+          g.skills.some((s) => s.petalId === petalFilter) || g.petalGrade > 0,
+      );
+    }
+
+    const sorted = [...filtered].sort((a, b) => {
+      if (sortMode === 'petal' && petalFilter != null) {
+        return b.petalGrade - a.petalGrade;
+      }
+      return b.snap.overall - a.snap.overall;
+    });
+    return sorted;
+  }, [guests, petalFilter, sortMode]);
+
+  const bannerPetal =
+    fromOnboarding && petalFilter != null ? getPetal(petalFilter) : null;
+
+  return (
+    <div className="stack">
+      <section className="card">
+        <h1>Conoce</h1>
+        <p className="muted">
+          Econautas por flor de skills — reputación visual, no keyword spam.
+        </p>
+        {bannerPetal ? (
+          <p className="meet-handoff-banner" role="status">
+            Estas flores hablan tu idioma — {bannerPetal.nameEs}.
+          </p>
+        ) : null}
+        <div className="petal-chips" role="group" aria-label="Filtrar por pétalo">
+          <button
+            type="button"
+            className={petalFilter == null ? 'petal-chip on' : 'petal-chip'}
+            onClick={() => {
+              setPetalFilter(null);
+              setSortMode('overall');
+            }}
+          >
+            Todos
+          </button>
+          {PETALS.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              className={petalFilter === p.id ? 'petal-chip on' : 'petal-chip'}
+              style={
+                petalFilter === p.id
+                  ? { color: p.color, borderColor: p.color }
+                  : undefined
+              }
+              onClick={() => {
+                setPetalFilter(p.id);
+                setSortMode('petal');
+              }}
+            >
+              {p.nameEs}
+            </button>
+          ))}
+        </div>
+        <label className="muted">
+          Ordenar{' '}
+          <select
+            value={sortMode}
+            onChange={(e) =>
+              setSortMode(e.target.value === 'petal' ? 'petal' : 'overall')
+            }
+            style={{ width: 'auto', display: 'inline-block', margin: 0 }}
+          >
+            <option value="overall">Flor general</option>
+            <option value="petal" disabled={petalFilter == null}>
+              Pétalo seleccionado
+            </option>
+          </select>
+        </label>
+      </section>
+
+      <section className="grid">
+        {ranked.length === 0 ? (
+          <div className="card">
+            <p className="muted">
+              {petalFilter
+                ? `Nadie con skills en ${getPetal(petalFilter).nameEs}.`
+                : 'Sin perfiles aún.'}
+            </p>
+          </div>
+        ) : (
+          ranked.map((g) => {
+            const isSelf = sessionUserId === g.userId;
+            return (
+              <article key={g.userId} className="card">
+                <Link
+                  href={`/profile/${encodeURIComponent(g.userId)}`}
+                  className="meet-card-link"
+                >
+                  <h2>{g.displayName}</h2>
+                  <p className="muted">
+                    <span className="badge">{g.accountClass}</span> · @
+                    {g.userId}
+                  </p>
+                  <FlowerViz snapshot={g.snap} compact />
+                  <ul>
+                    {g.skills.slice(0, 5).map((s) => (
+                      <li key={s.id}>
+                        {s.name} · {getPetal(s.petalId).nameEs}
+                      </li>
+                    ))}
+                  </ul>
+                </Link>
+                {sessionUserId && !isSelf && g.skills.length > 0 ? (
+                  <p style={{ marginTop: '0.75rem' }}>
+                    <Link
+                      href={`/profile/${encodeURIComponent(g.userId)}#attest`}
+                      className="btn secondary"
+                    >
+                      Atestar
+                    </Link>
+                  </p>
+                ) : null}
+              </article>
+            );
+          })
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/onboarding/FlowerReveal.tsx
+++ b/apps/web/components/onboarding/FlowerReveal.tsx
@@ -1,41 +1,63 @@
 'use client';
 
 import Link from 'next/link';
-import type { FlowerSnapshot, Skill } from '@ecologikal/domain';
+import type { FlowerSnapshot, PetalId, Skill } from '@ecologikal/domain';
 import { FlowerViz } from '@/components/FlowerViz';
+import { CopyLinkButton } from '@/components/CopyLinkButton';
 
 type Props = {
   snapshot: FlowerSnapshot;
   skills: Skill[];
   kinsEarned: number;
   displayName: string;
+  userId: string;
+  /** First chosen petal for Conoce handoff */
+  handoffPetalId: PetalId;
 };
 
 /**
- * Celebrated polar flower reveal after onboarding completes.
+ * Celebrated polar flower reveal — ownership (copy link) before Conoce.
  */
 export function FlowerReveal({
   snapshot,
   skills,
   kinsEarned,
   displayName,
+  userId,
+  handoffPetalId,
 }: Props) {
+  const publicPath = `/profile/${encodeURIComponent(userId)}`;
+  const meetHref = `/meet?petal=${handoffPetalId}&from=onboarding`;
+
   return (
     <div className="reveal-stage reveal-pulse onboard-step" data-stagger>
       <h1>Tu flor, {displayName}</h1>
       <p className="muted" style={{ margin: '0 auto', maxWidth: '26rem' }}>
-        Así te ven en Conoce. Cada pétalo crece con habilidades y atestaciones.
+        Así te ven en Conoce — y quien abra tu enlace.
       </p>
       <span className="kins-earn">+{kinsEarned} KINS ganados</span>
       <div className="flower-chart-row">
         <FlowerViz snapshot={snapshot} skills={skills} />
       </div>
       <div className="onboard-actions" style={{ justifyContent: 'center' }}>
-        <Link className="btn" href="/meet">
+        <CopyLinkButton url={publicPath} />
+        <Link className="btn secondary" href={publicPath}>
+          Ver mi flor pública
+        </Link>
+      </div>
+      <div
+        className="onboard-actions"
+        style={{ justifyContent: 'center', marginTop: '0.5rem' }}
+      >
+        <Link className="btn secondary" href={meetHref}>
           Ver Conoce
         </Link>
-        <Link className="btn secondary" href="/profile">
-          Ir a mi perfil
+        <Link
+          href="/profile"
+          className="muted"
+          style={{ fontSize: '0.85rem' }}
+        >
+          Editar más tarde
         </Link>
       </div>
     </div>

--- a/apps/web/components/onboarding/LoginClient.tsx
+++ b/apps/web/components/onboarding/LoginClient.tsx
@@ -63,9 +63,9 @@ export function LoginClient({ allowDevLogin, startSso, devLogin }: Props) {
 
         {allowDevLogin ? (
           <div className="login-demo">
-            <h2>Demo local</h2>
+            <h2>Demo econauta</h2>
             <p className="muted" style={{ fontSize: '0.8rem', margin: '0 0 0.75rem' }}>
-              Sin platform — solo desarrollo.
+              Sin platform — solo desarrollo. Guest es el camino hero.
             </p>
             <form action={devLogin}>
               <label htmlFor="username">Usuario</label>

--- a/apps/web/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/components/onboarding/OnboardingWizard.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import type { FlowerSnapshot, PetalId, Skill } from '@ecologikal/domain';
+import type {
+  FlowerSnapshot,
+  PetalId,
+  Skill,
+} from '@ecologikal/domain';
 import { PetalPicker } from './PetalPicker';
 import { SkillStep, type SkillDraft } from './SkillStep';
 import { FlowerReveal } from './FlowerReveal';
@@ -15,6 +19,8 @@ type Props = {
 };
 
 type CompleteResponse = {
+  userId: string;
+  petalIds: PetalId[];
   profile: { displayName: string };
   skills: Skill[];
   snapshot: FlowerSnapshot;
@@ -115,6 +121,8 @@ export function OnboardingWizard({
   }
 
   if (step === 3 && result) {
+    const handoffPetalId =
+      result.petalIds[0] ?? petals[0] ?? (4 as PetalId);
     return (
       <div className="onboard">
         <Progress step={3} />
@@ -123,6 +131,8 @@ export function OnboardingWizard({
           skills={result.skills}
           kinsEarned={result.kinsEarned}
           displayName={result.profile.displayName}
+          userId={result.userId}
+          handoffPetalId={handoffPetalId}
         />
       </div>
     );
@@ -135,9 +145,7 @@ export function OnboardingWizard({
       {step === 0 ? (
         <section className="onboard-step" data-stagger>
           <h1>Cómo te presentas</h1>
-          <p className="muted">
-            Empieza tu flor. Luego eliges en qué pétalos creces.
-          </p>
+          <p className="muted">Así te verán en tu flor pública.</p>
           <label htmlFor="displayName">Nombre</label>
           <input
             id="displayName"
@@ -161,7 +169,7 @@ export function OnboardingWizard({
           </p>
           <div className="onboard-actions">
             <button className="btn" type="button" onClick={goIdentityNext}>
-              Seguir
+              Continuar
             </button>
           </div>
         </section>
@@ -169,9 +177,9 @@ export function OnboardingWizard({
 
       {step === 1 ? (
         <section className="onboard-step" data-stagger>
-          <h1>Elige tus pétalos</h1>
+          <h1>¿En qué pétalos creces?</h1>
           <p className="muted">
-            Escoge 2 o 3 áreas donde quieres crecer y aportar.
+            Elige 2 o 3. Filtran Conoce y tu flor.
           </p>
           <PetalPicker selected={petals} onChange={syncDrafts} />
           {petalError ? <p className="field-error">{petalError}</p> : null}
@@ -184,7 +192,7 @@ export function OnboardingWizard({
               Atrás
             </button>
             <button className="btn" type="button" onClick={goPetalsNext}>
-              Seguir
+              Continuar
             </button>
           </div>
         </section>
@@ -192,9 +200,9 @@ export function OnboardingWizard({
 
       {step === 2 ? (
         <section className="onboard-step" data-stagger>
-          <h1>Tus primeras habilidades</h1>
+          <h1>Nombra lo que sabes</h1>
           <p className="muted">
-            Un nombre y un nivel por pétalo. Puedes añadir más después.
+            Nivel 1–5. Cada skill suma +3 KINS al completar.
           </p>
           <SkillStep
             petals={petals}
@@ -219,7 +227,7 @@ export function OnboardingWizard({
               disabled={pending}
               aria-busy={pending}
             >
-              {pending ? 'Creando tu flor…' : 'Crear mi flor'}
+              {pending ? 'Creando tu flor…' : 'Completar mi flor'}
             </button>
           </div>
         </section>

--- a/docs/DEMO_SCRIPT.md
+++ b/docs/DEMO_SCRIPT.md
@@ -34,9 +34,9 @@ Point to docs: `VERTICAL_PLAYBOOK.md` (+ Certexi `architecture/PLATFORM-INTEGRAT
 
 ### 2. Guest identity + flower (2m)
 
-1. `/v2/login` → **Demo local** as `guest1` / guest.
-2. `/v2/profile` → declare skill *Permacultura*, petal Tierra, level 3.
-3. Show flower bars + KINS +3.
+1. `/v2/login` → **Demo econauta** as a fresh guest (or `guest1` if not onboarded).
+2. `/v2/onboarding` → name → 2–3 pétalos → skill (e.g. *Permacultura*, Tierra, nivel 3) → **Completar mi flor**.
+3. Reveal: **Copiar enlace** / open `/v2/profile/{user}` — polar flower + KINS +3; then **Ver Conoce** (petal filter pre-set).
 
 ### 3. Host + eco-center (2m)
 
@@ -49,19 +49,20 @@ Point to docs: `VERTICAL_PLAYBOOK.md` (+ Certexi `architecture/PLATFORM-INTEGRAT
 
 Still as host:
 
-1. If `guest1` has a skill, **Atestar skill** → badge shows proof id (stub or live).
-2. **Completar voluntariado** for `guest1` on the vacancy → proof + KINS.
+1. Open `/v2/profile/guest1` (or Conoce → card → **Atestar**) → attest *Permacultura* → proof badge.
+2. Or use `/v2/admin` **Atestar skill** for the same loop.
+3. **Completar voluntariado** for `guest1` on the vacancy → proof + KINS.
 
 Switch to `guest1`:
 
-1. `/v2/profile` — references + verified badges.
+1. `/v2/profile` — polar flower + references + verified badges.
 2. `/v2/play` — ledger shows skill / reference / volunteer earns.
 3. `/v2/cooperate` — vacancy shows completion.
 
 ### 5. Intent IA (1m)
 
-Click pillars: Viaja (center), Aprende (Amplificate/Broadcast), Conoce (flowers),
-Descubre (places/needs).
+Click pillars: Viaja (center), Aprende (Amplificate/Broadcast), **Conoce**
+(filter Tierra, sort by flower, open public profile), Descubre (places/needs).
 
 ### 6. Close (30s)
 

--- a/packages/domain/src/flower.test.ts
+++ b/packages/domain/src/flower.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { flowerGrade, petalGrade } from './flower';
+import { flowerGrade, flowerSnapshot, petalGrade } from './flower';
 import type { Skill, SkillReference } from './skills';
 
 describe('flower grades', () => {
@@ -58,4 +58,28 @@ describe('flower grades', () => {
     assert.equal(petalGrade(skills, refs, 1), 4);
     assert.ok(flowerGrade(skills, refs) > 0);
   });
+
+  it('flowerSnapshot lists all 7 petals with empty petals at 0', () => {
+    const skills: Skill[] = [
+      {
+        id: 's1',
+        userId: 'u1',
+        petalId: 4,
+        name: 'Permaculture',
+        level: 3,
+        createdAt: '2026-01-01',
+      },
+    ];
+    const snap = flowerSnapshot(skills, []);
+    assert.equal(snap.petals.length, 7);
+    assert.equal(snap.overall, 3);
+    for (const p of snap.petals) {
+      if (p.petalId === 4) {
+        assert.equal(p.grade, 3);
+      } else {
+        assert.equal(p.grade, 0);
+      }
+    }
+  });
 });
+


### PR DESCRIPTION
## Summary
- Reveal primary action is **Copiar enlace** / flor pública (not Conoce dump)
- Public `/profile/[userId]` Spanish OG + copy chip + logged-out CTA
- Conoce handoff via `?petal=&from=onboarding` with banner
- Guest-first home + DEMO_SCRIPT aligned to wizard → reveal → share

## Risk
Low–medium (UX/copy + Meet filter init). Domain grade math unchanged. No new deps.

## Verification
- Harness (`:3100`): fresh demo guest → wizard → reveal shows Copiar enlace; Ver Conoce → `/meet?petal=4&from=onboarding` with Tierra banner
- API: complete returns `userId` + `petalIds`; home has Empezar mi flor; public page includes flor Ecologikal OG title
- Audit: domain tests 3/3, web typecheck + production build green

## Rollback
Revert this PR (7 commits on `feat/flor-publica-p0`).

## Test plan
- [ ] Demo login as new guest → complete onboarding → Copiar enlace copies `/profile/{user}`
- [ ] Ver mi flor pública loads OG title/description
- [ ] Ver Conoce lands with petal filter + handoff banner
- [ ] `/` shows guest hero; Vintage/seed only under Desarrollo
- [ ] Host demo still skips wizard → admin


Made with [Cursor](https://cursor.com)