### PR TITLE
Cinematic glass theme: dual mode + Agroabundanza flagship home

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@ecologikal/web", "exec", "next", "dev"],
+      "port": 3100,
+      "autoPort": true
+    }
+  ]
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,86 @@
+# Design
+
+Visual system for the Ecologikal revival (`apps/web`). Pairs with PRODUCT.md.
+
+## Theme
+
+Dual-theme, both first-class. Scene: *a guest opens the platform under a palapa
+at golden hour (light); that night an econauta browses vacancies in a candle-lit
+common room (dark).* Dark is the cinematic default for the brand surfaces; the
+stored user choice wins everywhere.
+
+Mechanics: `data-theme="dark" | "light"` on `<html>`, set pre-hydration from
+`localStorage('eco-theme')`, falling back to `prefers-color-scheme`. All colors
+are CSS custom properties; no hardcoded hex in components.
+
+## Color (OKLCH)
+
+Strategy: **Committed** — the dusk-forest ground carries the surface; one gold
+thread of luxury ≤ 10%.
+
+### Dark (dusk at the center)
+
+- `--bg`: oklch(0.16 0.02 165) — forest night, green-tinted, never #000
+- `--bg-elev`: oklch(0.20 0.025 163)
+- `--ink`: oklch(0.94 0.012 120) — warm off-white
+- `--muted`: oklch(0.68 0.03 150)
+- `--gold`: oklch(0.78 0.10 85) — the luxury thread (Agroabundanza gold)
+- `--green`: oklch(0.52 0.10 155) · `--green-bright`: oklch(0.72 0.13 150)
+- Sunset scene ramp: oklch(0.75 0.14 55) → oklch(0.55 0.12 35) ambers
+
+### Light (daylight in the field)
+
+- `--bg`: oklch(0.965 0.008 95) — warm ivory
+- `--bg-elev`: oklch(0.99 0.005 95)
+- `--ink`: oklch(0.24 0.03 160) — deep green ink
+- `--muted`: oklch(0.50 0.03 150)
+- `--gold`: oklch(0.62 0.11 80) (darkened for AA on ivory)
+- `--green`: oklch(0.46 0.10 155) · `--green-bright`: oklch(0.52 0.12 150)
+
+## Glass (purposeful, skeuomorphic-clear)
+
+Glass = translucent panel + backdrop blur/saturate + hairline border + inner top
+highlight (the "clear glass" edge). Used ONLY: sticky nav, panels floating over
+imagery (hero, flagship), theme toggle. Regular cards stay solid `--bg-elev`.
+
+```css
+--glass-bg: color-mix(in oklab, var(--bg-elev) 55%, transparent);
+--glass-border: color-mix(in oklab, var(--ink) 14%, transparent);
+--glass-highlight: inset 0 1px 0 color-mix(in oklab, white 12%, transparent);
+backdrop-filter: blur(18px) saturate(1.4);
+```
+
+Fallback: `@supports not (backdrop-filter: blur(1px))` → raise bg opacity to 92%.
+
+## Typography
+
+- **Display**: Fraunces (variable, optical size) — h1/h2/brand/kickers. Modest
+  luxury serif; use `font-variation-settings` soft optical sizing.
+- **Body/UI**: Geist Sans (existing). Mono: Geist Mono.
+- Scale ratio ≥1.25; hero clamps to ~4rem. Body max 70ch.
+- Kickers: 0.75rem, uppercase, letter-spacing 0.14em, gold.
+
+## Imagery
+
+Crafted inline SVG, theme-aware via CSS variables (no external assets):
+
+1. **Valle hero** — layered ridgelines, low sun, terraced field rows, haze;
+   amber dusk in dark, morning gold in light.
+2. **Flagship aerial** — Agroabundanza motif: curved crop rows, laguna, airstrip
+   ribbon, bamboo perimeter.
+Grain: subtle SVG turbulence overlay ≤4% opacity for the cinematic finish.
+
+## Motion
+
+- Easings: `--ease-out: cubic-bezier(0.23,1,0.32,1)`; UI ≤ 250ms.
+- Buttons: `scale(0.97)` on `:active`.
+- Entrances: `@starting-style` fades with ≤8px rise, stagger 40–60ms, home only.
+- `prefers-reduced-motion`: opacity-only.
+
+## Components
+
+- `.btn` pill: green primary; gold reserved for the single flagship CTA.
+- `.badge`: hairline, tinted; petal badges pair color + number + name.
+- `.rail`: horizontal scroll row (Netflix-like) with scroll-snap, edge fade masks.
+- `.glass-panel`: the only translucent container; never nested.
+- Focus: 2px `--green-bright` outline, 2px offset, both themes.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,70 @@
+# Product
+
+## Register
+
+product
+
+(Home page and login are brand surfaces; the six-pillar app screens are product surfaces. Default register is product; override to brand when working on `/` or `/login`.)
+
+## Users
+
+Two people, one platform:
+
+1. **The retreat guest / econauta** — arrives through a sustainable center like
+   Agroabundanza Institute. Browses on a laptop under a palapa at golden hour or
+   on a phone in a candle-lit common room at night. Job: find their place in the
+   regenerative network — declare skills, join a retreat, volunteer, travel.
+2. **The center host** — runs an eco-center (Agroabundanza Institute is the
+   flagship). Publishes workshops, vacancies, and retreats; reviews volunteers by
+   skill flower. Job: fill the center with the right people and keep the KINS
+   economy flowing.
+
+Spanish-first audience (Monterrey origin), bilingual-friendly.
+
+## Product Purpose
+
+Ecologikal is the operating platform for regenerative participation: skills by
+7 petals, peer-attested flower reputation, KINS ecosocial currency, eco-centers
+as first-class venues, six intent modes (Juega · Viaja · Descubre · Aprende ·
+Conoce · Coopera). Agroabundanza Institute — a 330-hectare family institute
+(Regenerar · Educar · Elevar) — is the flagship center that uses this platform to
+deliver retreats where people work on real social and ecological problems.
+Success: a guest lands, feels the mission cinematically, and within minutes has a
+flower started and a retreat or vacancy in view.
+
+## Brand Personality
+
+Modest luxury with a conscience. Cinematic, Netflix-like storytelling in service
+of social impact, never spectacle for its own sake. Three words: **regenerative,
+composed, luminous**. The feel of clear glass over living land: translucent
+surfaces, warm dusk light, deep forest calm. Confidence without shouting;
+abundance that reads as stewardship, not wealth.
+
+## Anti-references
+
+- 2012 Facebook chrome (the vintage archive is memory, not a target)
+- Generic SaaS dashboards: white cards on gray, hero-metric templates
+- Crypto/greenwash gloss: neon greens, token-hype energy
+- Eco-clichés: cartoon leaves, recycled-paper textures, sandal-brown earnestness
+- Infinite-scroll dopamine patterns; vanity metrics
+
+## Design Principles
+
+1. **Land is the protagonist** — imagery of terrain, light, and water carries the
+   story; UI floats above it as clear glass.
+2. **Dusk and daylight are both true** — dark mode is the cinematic evening
+   default of a retreat; light mode is the working daylight of the field. Both
+   are first-class.
+3. **Luxury through restraint** — one gold thread, generous space, serif display
+   type. Never more than one indulgence per screen.
+4. **Impact is legible** — petals, KINS, and flower grades are shown as living
+   systems, not stat chips.
+5. **Glass is purposeful** — translucency only where content floats over imagery
+   or the surface needs depth; solid calm elsewhere.
+
+## Accessibility & Inclusion
+
+WCAG 2.1 AA contrast in both themes. `prefers-reduced-motion` honored (fade, no
+parallax/movement). Hover effects gated to `(hover: hover) and (pointer: fine)`.
+Petal colors never the sole signal (always paired with number + name). Spanish
+copy is the primary voice.

--- a/apps/web/app/api/seed/route.ts
+++ b/apps/web/app/api/seed/route.ts
@@ -35,10 +35,11 @@ export async function POST() {
     if (!center) {
       center = {
         id: uid('center'),
-        name: 'Ecoaldea Aurora',
-        slug: 'aurora',
+        name: 'Agroabundanza Institute',
+        slug: 'agroabundanza',
         hostUserId: hostId || 'host1',
-        summary: 'Centro regenerativo de demostración.',
+        summary:
+          'Instituto familiar de 330 ha — regenerar, educar y elevar mediante agro-tech sustentable.',
         type: 'ecovillage',
         status: 'forming',
         createdAt: now,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,22 +1,125 @@
 @import 'tailwindcss';
 
+/* ————————————————————————————————————————————————————————————————
+   Ecologikal — dusk-forest theme, clear glass over living land.
+   Dual theme: light on :root; dark via system fallback + [data-theme].
+   Stored choice ([data-theme]) always wins over the system preference.
+   ———————————————————————————————————————————————————————————————— */
+
 :root {
-  --bg: #121c16;
-  --bg-elev: #1a2820;
-  --ink: #eef2eb;
-  --muted: #9aab9c;
-  --green: #3d7348;
-  --green-bright: #6aad72;
-  --accent: #b8964e;
-  --pink: #c45a72;
-  --blue: #4a6580;
-  --line: rgba(238, 242, 235, 0.12);
-  --radius: 12px;
+  /* Light — daylight in the field */
+  --bg: oklch(0.965 0.008 95);
+  --bg-elev: oklch(0.99 0.005 95);
+  --ink: oklch(0.24 0.03 160);
+  --muted: oklch(0.48 0.03 150);
+  --green: oklch(0.46 0.1 155);
+  --green-bright: oklch(0.5 0.12 150);
+  --gold: oklch(0.58 0.11 80);
+  --accent: var(--gold);
+  --pink: oklch(0.6 0.13 10);
+  --blue: oklch(0.5 0.08 250);
+  --line: color-mix(in oklab, var(--ink) 14%, transparent);
+
+  /* Clear glass */
+  --glass-bg: color-mix(in oklab, var(--bg-elev) 55%, transparent);
+  --glass-bg-strong: color-mix(in oklab, var(--bg-elev) 74%, transparent);
+  --glass-border: color-mix(in oklab, var(--ink) 16%, transparent);
+  --glass-highlight: inset 0 1px 0
+    color-mix(in oklab, white 55%, transparent);
+  --glass-shadow: 0 18px 50px -22px
+    color-mix(in oklab, var(--ink) 38%, transparent);
+
+  /* Cinematic scene (morning gold) */
+  --sky-hi: oklch(0.93 0.045 85);
+  --sky-lo: oklch(0.85 0.075 70);
+  --sun: oklch(0.88 0.115 80);
+  --haze: oklch(0.9 0.03 95);
+  --ridge-far: oklch(0.72 0.05 150);
+  --ridge-mid: oklch(0.58 0.07 152);
+  --ridge-near: oklch(0.44 0.08 155);
+  --field: oklch(0.66 0.09 130);
+  --field-row: oklch(0.58 0.09 135);
+  --water: oklch(0.78 0.05 220);
+
+  --radius: 14px;
   --font: var(--font-geist-sans), 'Segoe UI', 'Avenir Next', system-ui,
     sans-serif;
+  --font-display: var(--font-fraunces), Georgia, 'Times New Roman', serif;
   --font-mono: var(--font-geist-mono), ui-monospace, monospace;
   --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
   --duration-ui: 180ms;
+  color-scheme: light;
+}
+
+/* Dark — dusk at the center. System preference… */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --bg: oklch(0.16 0.02 165);
+    --bg-elev: oklch(0.2 0.025 163);
+    --ink: oklch(0.94 0.012 120);
+    --muted: oklch(0.68 0.03 150);
+    --green: oklch(0.52 0.1 155);
+    --green-bright: oklch(0.72 0.13 150);
+    --gold: oklch(0.78 0.1 85);
+    --pink: oklch(0.68 0.12 10);
+    --blue: oklch(0.68 0.07 250);
+    --line: color-mix(in oklab, var(--ink) 13%, transparent);
+
+    --glass-bg: color-mix(in oklab, var(--bg-elev) 52%, transparent);
+    --glass-bg-strong: color-mix(in oklab, var(--bg-elev) 72%, transparent);
+    --glass-border: color-mix(in oklab, var(--ink) 15%, transparent);
+    --glass-highlight: inset 0 1px 0
+      color-mix(in oklab, white 12%, transparent);
+    --glass-shadow: 0 22px 60px -24px
+      color-mix(in oklab, black 70%, transparent);
+
+    --sky-hi: oklch(0.34 0.05 55);
+    --sky-lo: oklch(0.52 0.11 50);
+    --sun: oklch(0.82 0.13 75);
+    --haze: oklch(0.42 0.06 55);
+    --ridge-far: oklch(0.32 0.04 160);
+    --ridge-mid: oklch(0.26 0.035 162);
+    --ridge-near: oklch(0.21 0.03 164);
+    --field: oklch(0.31 0.05 145);
+    --field-row: oklch(0.27 0.045 148);
+    --water: oklch(0.45 0.06 230);
+    color-scheme: dark;
+  }
+}
+
+/* …and the explicit toggle wins in both directions. */
+:root[data-theme='dark'] {
+  --bg: oklch(0.16 0.02 165);
+  --bg-elev: oklch(0.2 0.025 163);
+  --ink: oklch(0.94 0.012 120);
+  --muted: oklch(0.68 0.03 150);
+  --green: oklch(0.52 0.1 155);
+  --green-bright: oklch(0.72 0.13 150);
+  --gold: oklch(0.78 0.1 85);
+  --pink: oklch(0.68 0.12 10);
+  --blue: oklch(0.68 0.07 250);
+  --line: color-mix(in oklab, var(--ink) 13%, transparent);
+
+  --glass-bg: color-mix(in oklab, var(--bg-elev) 52%, transparent);
+  --glass-bg-strong: color-mix(in oklab, var(--bg-elev) 72%, transparent);
+  --glass-border: color-mix(in oklab, var(--ink) 15%, transparent);
+  --glass-highlight: inset 0 1px 0
+    color-mix(in oklab, white 12%, transparent);
+  --glass-shadow: 0 22px 60px -24px
+    color-mix(in oklab, black 70%, transparent);
+
+  --sky-hi: oklch(0.34 0.05 55);
+  --sky-lo: oklch(0.52 0.11 50);
+  --sun: oklch(0.82 0.13 75);
+  --haze: oklch(0.42 0.06 55);
+  --ridge-far: oklch(0.32 0.04 160);
+  --ridge-mid: oklch(0.26 0.035 162);
+  --ridge-near: oklch(0.21 0.03 164);
+  --field: oklch(0.31 0.05 145);
+  --field-row: oklch(0.27 0.045 148);
+  --water: oklch(0.45 0.06 230);
+  color-scheme: dark;
 }
 
 * {
@@ -27,13 +130,38 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background:
-    radial-gradient(1100px 560px at 8% -8%, #1a3324 0%, transparent 55%),
-    radial-gradient(800px 420px at 92% 0%, #243028 0%, transparent 48%),
-    var(--bg);
+  background: var(--bg);
   color: var(--ink);
   font-family: var(--font);
   min-height: 100%;
+}
+
+body {
+  /* .full-bleed uses 50vw math; vw includes the scrollbar — clip the sliver */
+  overflow-x: clip;
+  background:
+    radial-gradient(
+      1200px 620px at 12% -10%,
+      color-mix(in oklab, var(--green) 16%, transparent) 0%,
+      transparent 58%
+    ),
+    radial-gradient(
+      900px 480px at 95% -4%,
+      color-mix(in oklab, var(--gold) 10%, transparent) 0%,
+      transparent 50%
+    ),
+    var(--bg);
+}
+
+/* Cinematic grain — barely there, fixed, non-interactive */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 60;
+  opacity: 0.032;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
 a {
@@ -45,27 +173,77 @@ a:hover {
   text-decoration: underline;
 }
 
+::selection {
+  background: color-mix(in oklab, var(--gold) 30%, transparent);
+}
+
 .shell {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 1.25rem 1.5rem 4rem;
+  padding: 0 1.5rem 4rem;
 }
 
+/* Escape the shell for full-bleed cinema */
+.full-bleed {
+  margin-inline: calc(50% - 50vw);
+}
+
+/* ——— Glass ——— */
+.glass-panel {
+  background: var(--glass-bg-strong);
+  border: 1px solid var(--glass-border);
+  border-radius: calc(var(--radius) + 4px);
+  box-shadow: var(--glass-highlight), var(--glass-shadow);
+  backdrop-filter: blur(18px) saturate(1.4);
+  -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .glass-panel {
+    background: color-mix(in oklab, var(--bg-elev) 94%, transparent);
+  }
+}
+
+/* ——— Nav: floating glass bar ——— */
 .nav {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 50;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem 1rem;
   align-items: center;
   justify-content: space-between;
-  padding: 0.75rem 0 1.5rem;
-  border-bottom: 1px solid var(--line);
-  margin-bottom: 2rem;
+  padding: 0.6rem 1rem;
+  margin: 0.75rem 0 2rem;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  box-shadow: var(--glass-highlight), var(--glass-shadow);
+  backdrop-filter: blur(18px) saturate(1.4);
+  -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+  .nav {
+    background: color-mix(in oklab, var(--bg-elev) 94%, transparent);
+  }
+}
+
+/* On small screens the wrapped nav is tall — pin it back into the flow. */
+@media (max-width: 719px) {
+  .nav {
+    position: static;
+    border-radius: calc(var(--radius) + 6px);
+    padding: 0.75rem 1rem;
+  }
 }
 
 .brand {
-  font-size: 1.35rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   color: var(--ink);
 }
 
@@ -76,12 +254,12 @@ a:hover {
 .pillars {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .pillars a {
   color: var(--muted);
-  padding: 0.35rem 0.65rem;
+  padding: 0.35rem 0.7rem;
   border-radius: 999px;
   border: 1px solid transparent;
   font-size: 0.9rem;
@@ -95,12 +273,42 @@ a:hover {
 .pillars a.active {
   color: var(--ink);
   border-color: var(--line);
-  background: var(--bg-elev);
+  background: color-mix(in oklab, var(--bg-elev) 70%, transparent);
   text-decoration: none;
 }
 
+/* ——— Theme toggle ——— */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    transform 140ms var(--ease-out),
+    color var(--duration-ui) var(--ease-out),
+    border-color var(--duration-ui) var(--ease-out);
+}
+
+.theme-toggle:active {
+  transform: scale(0.92);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .theme-toggle:hover {
+    color: var(--gold);
+    border-color: color-mix(in oklab, var(--gold) 45%, transparent);
+  }
+}
+
+/* ——— Surfaces ——— */
 .card {
-  background: color-mix(in srgb, var(--bg-elev) 88%, transparent);
+  background: var(--bg-elev);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 1.25rem 1.4rem;
@@ -113,14 +321,22 @@ a:hover {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+/* ——— Type ——— */
+h1,
+h2 {
+  font-family: var(--font-display);
+  font-weight: 550;
+  letter-spacing: 0.005em;
+}
+
 h1 {
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
   margin: 0 0 0.5rem;
-  line-height: 1.15;
+  line-height: 1.12;
 }
 
 h2 {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   margin: 0 0 0.75rem;
 }
 
@@ -128,6 +344,17 @@ h2 {
   color: var(--muted);
 }
 
+.kicker {
+  font-family: var(--font);
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--gold);
+  margin: 0 0 0.75rem;
+}
+
+/* ——— Buttons ——— */
 .btn {
   display: inline-flex;
   align-items: center;
@@ -135,16 +362,18 @@ h2 {
   gap: 0.4rem;
   border: 0;
   border-radius: 999px;
-  padding: 0.65rem 1.1rem;
+  padding: 0.65rem 1.15rem;
   background: var(--green);
-  color: white;
+  color: oklch(0.97 0.01 120);
   font-weight: 600;
   font-family: inherit;
+  font-size: 0.95rem;
   cursor: pointer;
   transition:
-    transform var(--duration-ui) var(--ease-out),
+    transform 140ms var(--ease-out),
     opacity var(--duration-ui) var(--ease-out),
-    background var(--duration-ui) var(--ease-out);
+    background var(--duration-ui) var(--ease-out),
+    border-color var(--duration-ui) var(--ease-out);
 }
 
 .btn:active:not(:disabled) {
@@ -157,6 +386,11 @@ h2 {
   color: var(--ink);
 }
 
+.btn.gold {
+  background: var(--gold);
+  color: oklch(0.2 0.03 90);
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -164,21 +398,27 @@ h2 {
 
 @media (hover: hover) and (pointer: fine) {
   .btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--green) 85%, white);
+    background: color-mix(in oklab, var(--green) 86%, white);
   }
 
   .btn.secondary:hover:not(:disabled) {
-    background: var(--bg-elev);
+    background: color-mix(in oklab, var(--bg-elev) 80%, transparent);
+    border-color: color-mix(in oklab, var(--ink) 26%, transparent);
+  }
+
+  .btn.gold:hover:not(:disabled) {
+    background: color-mix(in oklab, var(--gold) 88%, white);
   }
 }
 
+/* ——— Forms ——— */
 input,
 select,
 textarea {
   width: 100%;
-  background: var(--bg);
+  background: color-mix(in oklab, var(--bg) 70%, var(--bg-elev));
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--ink);
   padding: 0.55rem 0.7rem;
   margin: 0.35rem 0 0.8rem;
@@ -190,7 +430,7 @@ input:focus,
 select:focus,
 textarea:focus {
   outline: none;
-  border-color: color-mix(in srgb, var(--green-bright) 55%, var(--line));
+  border-color: color-mix(in oklab, var(--green-bright) 60%, var(--line));
 }
 
 label {
@@ -198,20 +438,262 @@ label {
   color: var(--muted);
 }
 
+/* ——— Badges ——— */
 .badge {
   display: inline-block;
   font-size: 0.75rem;
-  padding: 0.15rem 0.5rem;
+  padding: 0.15rem 0.55rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 25%, transparent);
-  color: var(--accent);
-  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  background: color-mix(in oklab, var(--gold) 14%, transparent);
+  color: var(--gold);
+  border: 1px solid color-mix(in oklab, var(--gold) 38%, transparent);
 }
 
 .badge.verified {
-  background: color-mix(in srgb, var(--green-bright) 20%, transparent);
+  background: color-mix(in oklab, var(--green-bright) 14%, transparent);
   color: var(--green-bright);
-  border-color: color-mix(in srgb, var(--green-bright) 40%, transparent);
+  border-color: color-mix(in oklab, var(--green-bright) 38%, transparent);
+}
+
+/* ——— Cinematic hero ——— */
+.cine-hero {
+  position: relative;
+  min-height: clamp(480px, 68vh, 640px);
+  display: flex;
+  align-items: flex-end;
+  overflow: clip;
+  border-radius: 0 0 calc(var(--radius) + 10px) calc(var(--radius) + 10px);
+}
+
+.cine-hero .scene {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.cine-hero .scene svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* dusk vignette so glass text always reads */
+.cine-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    color-mix(in oklab, var(--bg) 55%, transparent) 0%,
+    transparent 45%
+  );
+  pointer-events: none;
+}
+
+.cine-content {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem 2.5rem;
+}
+
+.cine-panel {
+  max-width: 34rem;
+  padding: 1.75rem 2rem;
+}
+
+.cine-panel .brand-mark {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 5.5vw, 3.9rem);
+  font-weight: 560;
+  letter-spacing: -0.015em;
+  line-height: 1.04;
+  margin: 0 0 0.85rem;
+  color: var(--ink);
+}
+
+.cine-panel .brand-mark em {
+  font-style: italic;
+  color: var(--green-bright);
+}
+
+.cine-panel .promise {
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  line-height: 1.45;
+  margin: 0 0 0.5rem;
+  color: var(--ink);
+}
+
+.cine-panel .home-support {
+  margin: 0;
+  max-width: 28rem;
+  font-size: 0.95rem;
+}
+
+/* Entrance: fade + gentle rise, once */
+.cine-panel,
+.rail,
+.flagship {
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    opacity 600ms var(--ease-out),
+    transform 600ms var(--ease-out);
+
+  @starting-style {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
+
+.rail {
+  transition-delay: 90ms;
+}
+
+.flagship-inner,
+.home-dev {
+  transition-delay: 140ms;
+}
+
+/* ——— Pillar rail (streaming-row feel) ——— */
+.rail {
+  display: flex;
+  gap: 0.85rem;
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+  padding: 0.25rem 0.25rem 0.85rem;
+  scrollbar-width: thin;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 1.25rem,
+    black calc(100% - 1.75rem),
+    transparent 100%
+  );
+}
+
+.rail-card {
+  scroll-snap-align: start;
+  flex: 0 0 15.5rem;
+  display: block;
+  position: relative;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(
+      160deg,
+      color-mix(in oklab, var(--tile, var(--green)) 22%, var(--bg-elev)) 0%,
+      var(--bg-elev) 70%
+    );
+  color: var(--ink);
+  padding: 1.1rem 1.2rem 1rem;
+  min-height: 8.25rem;
+  overflow: clip;
+  transition:
+    transform 200ms var(--ease-out),
+    border-color 200ms var(--ease-out);
+}
+
+.rail-card:hover {
+  text-decoration: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .rail-card:hover {
+    transform: translateY(-3px);
+    border-color: color-mix(in oklab, var(--tile, var(--green)) 45%, var(--line));
+  }
+}
+
+.rail-card .rail-icon {
+  color: color-mix(in oklab, var(--tile, var(--green)) 70%, var(--ink));
+  margin-bottom: 0.6rem;
+}
+
+.rail-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 560;
+  margin: 0 0 0.25rem;
+}
+
+.rail-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+/* ——— Flagship (Agroabundanza) ——— */
+.flagship {
+  position: relative;
+  margin-top: 2.5rem;
+  border-radius: calc(var(--radius) + 8px);
+  overflow: clip;
+  min-height: 20rem;
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--line);
+}
+
+.flagship .scene {
+  position: absolute;
+  inset: 0;
+}
+
+.flagship .scene svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.flagship-inner {
+  position: relative;
+  z-index: 2;
+  align-self: flex-end;
+  margin: 1.5rem;
+  max-width: 26rem;
+  padding: 1.5rem 1.75rem;
+}
+
+.flagship-inner h2 {
+  margin-bottom: 0.4rem;
+}
+
+.flagship-inner .principles {
+  display: flex;
+  gap: 0.4rem 0.9rem;
+  flex-wrap: wrap;
+  margin: 0.75rem 0 1rem;
+  padding: 0;
+  list-style: none;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 2.75rem 0 1rem;
+}
+
+.section-head h2 {
+  margin: 0;
+}
+
+/* ——— Petal strip ——— */
+.petal-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
 }
 
 /* Polar skill flower */
@@ -280,11 +762,15 @@ label {
 
 .flower-panel {
   margin-top: 1rem;
-  padding: 1rem;
+  padding: 1rem 1.1rem;
   border-radius: var(--radius);
-  border: 1px solid var(--line);
-  border-left-width: 4px;
-  background: var(--bg);
+  border: 1px solid
+    color-mix(in oklab, var(--petal-color, var(--green)) 35%, var(--line));
+  background: color-mix(
+    in oklab,
+    var(--petal-color, var(--green)) 7%,
+    var(--bg-elev)
+  );
 }
 
 .flower-panel h3 {
@@ -360,7 +846,7 @@ label {
 }
 
 .field-error {
-  color: #e8a0a0;
+  color: var(--pink);
   font-size: 0.8rem;
   margin: -0.5rem 0 0.75rem;
 }
@@ -388,16 +874,17 @@ label {
 }
 
 .login-brand .brand-mark {
+  font-family: var(--font-display);
   font-size: clamp(2.4rem, 5vw, 3.6rem);
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-weight: 560;
+  letter-spacing: -0.015em;
   line-height: 1.05;
   margin: 0 0 1rem;
   color: var(--ink);
 }
 
 .login-brand .brand-mark em {
-  font-style: normal;
+  font-style: italic;
   color: var(--green-bright);
 }
 
@@ -414,6 +901,7 @@ label {
   flex-direction: column;
   gap: 1.5rem;
   max-width: 22rem;
+  padding: 1.75rem;
 }
 
 .login-primary {
@@ -435,6 +923,7 @@ label {
 }
 
 .login-demo h2 {
+  font-family: var(--font);
   font-size: 0.85rem;
   font-weight: 500;
   color: var(--muted);
@@ -514,8 +1003,25 @@ label {
     animation: none !important;
   }
 
-  .btn:active:not(:disabled) {
+  .btn:active:not(:disabled),
+  .theme-toggle:active {
     transform: none;
+  }
+
+  .cine-panel,
+  .rail,
+  .flagship {
+    transition-property: opacity;
+
+    @starting-style {
+      transform: none;
+    }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .rail-card:hover {
+      transform: none;
+    }
   }
 }
 
@@ -545,7 +1051,7 @@ label {
   padding: 1rem 0.9rem;
   border-radius: 14px;
   border: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg-elev) 70%, transparent);
+  background: color-mix(in oklab, var(--bg-elev) 70%, transparent);
   color: var(--ink);
   cursor: pointer;
   font-family: inherit;
@@ -579,12 +1085,12 @@ label {
 .petal-opt.selected {
   border-color: var(--petal-color, var(--green-bright));
   background: color-mix(
-    in srgb,
-    var(--petal-color, var(--green)) 18%,
+    in oklab,
+    var(--petal-color, var(--green)) 16%,
     var(--bg-elev)
   );
   box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--petal-color, var(--green)) 40%, transparent);
+    color-mix(in oklab, var(--petal-color, var(--green)) 40%, transparent);
 }
 
 .petal-opt:disabled {
@@ -593,12 +1099,16 @@ label {
 }
 
 .skill-block {
-  border: 1px solid var(--line);
+  border: 1px solid
+    color-mix(in oklab, var(--petal-color, var(--green)) 32%, var(--line));
   border-radius: var(--radius);
   padding: 1rem 1.1rem;
   margin-bottom: 0.85rem;
-  border-left: 3px solid var(--petal-color, var(--green));
-  background: color-mix(in srgb, var(--bg-elev) 60%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--petal-color, var(--green)) 6%,
+    var(--bg-elev)
+  );
 }
 
 .skill-block h3 {
@@ -659,8 +1169,8 @@ label {
   margin: 0.5rem 0 1.25rem;
   padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
-  color: var(--accent);
+  border: 1px solid color-mix(in oklab, var(--gold) 45%, transparent);
+  color: var(--gold);
   font-size: 0.9rem;
   font-weight: 600;
 }
@@ -683,28 +1193,30 @@ label {
   margin: 0.85rem 0 0;
   padding: 0.65rem 0.85rem;
   border-radius: 8px;
-  border: 1px solid color-mix(in srgb, var(--green-bright) 35%, var(--line));
-  background: color-mix(in srgb, var(--green) 14%, var(--bg-elev));
+  border: 1px solid color-mix(in oklab, var(--green-bright) 35%, var(--line));
+  background: color-mix(in oklab, var(--green) 12%, var(--bg-elev));
   color: var(--ink);
   font-size: 0.9rem;
 }
 
+/* Legacy hero classes (other screens reference them) */
 .home-hero {
   padding: 2rem 0 1rem;
   max-width: 36rem;
 }
 
 .home-hero .brand-mark {
+  font-family: var(--font-display);
   font-size: clamp(2.4rem, 5vw, 3.4rem);
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-weight: 560;
+  letter-spacing: -0.015em;
   line-height: 1.05;
   margin: 0 0 1rem;
   color: var(--ink);
 }
 
 .home-hero .brand-mark em {
-  font-style: normal;
+  font-style: italic;
   color: var(--green-bright);
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -356,6 +356,8 @@ h2 {
 
 /* ——— Buttons ——— */
 .btn {
+  position: relative;
+  overflow: clip;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -550,10 +552,9 @@ label {
   font-size: 0.95rem;
 }
 
-/* Entrance: fade + gentle rise, once */
-.cine-panel,
-.rail,
-.flagship {
+/* Entrance: the glass panel arrives once; its content is choreographed
+   word-by-word in the Living Land block at the end of this file. */
+.cine-panel {
   opacity: 1;
   transform: translateY(0);
   transition:
@@ -564,15 +565,6 @@ label {
     opacity: 0;
     transform: translateY(10px);
   }
-}
-
-.rail {
-  transition-delay: 90ms;
-}
-
-.flagship-inner,
-.home-dev {
-  transition-delay: 140ms;
 }
 
 /* ——— Pillar rail (streaming-row feel) ——— */
@@ -1025,9 +1017,7 @@ label {
     transform: none;
   }
 
-  .cine-panel,
-  .rail,
-  .flagship {
+  .cine-panel {
     transition-property: opacity;
 
     @starting-style {
@@ -1253,4 +1243,305 @@ label {
 .home-dev {
   margin-top: 2rem;
   opacity: 0.85;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Living Land — the landing breathes.
+   All motion is opt-in via prefers-reduced-motion: no-preference.
+   Scroll-driven choreography is @supports-guarded; without support the
+   page is simply still and fully visible. Transform/opacity only,
+   except the one-shot crop-row draw (small area, scroll-scrubbed).
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* Word layout is unconditional — motion preference must never change copy. */
+.hero-word {
+  display: inline-block;
+  margin-right: 0.28em;
+}
+
+.hero-word:last-child {
+  margin-right: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /* — Hero orchestration: kicker → words → promise → actions — */
+  .hero-rise,
+  .hero-word {
+    opacity: 0;
+    animation: hero-rise 700ms var(--ease-out) both;
+    animation-delay: calc(180ms + var(--i, 0) * 85ms);
+  }
+
+  @keyframes hero-rise {
+    from {
+      opacity: 0;
+      transform: translateY(16px);
+      filter: blur(7px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+    }
+  }
+
+  /* — Birds: slow thermal drift, each on its own clock — */
+  .birds path {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: bird-drift 11s ease-in-out infinite alternate;
+  }
+
+  .birds path:nth-child(2) {
+    animation-duration: 14s;
+    animation-delay: -4s;
+  }
+
+  .birds path:nth-child(3) {
+    animation-duration: 9s;
+    animation-delay: -7s;
+  }
+
+  @keyframes bird-drift {
+    from {
+      transform: translate(0, 0);
+    }
+    to {
+      transform: translate(30px, -12px);
+    }
+  }
+
+  /* — Campus lamps breathe (staggered inline delays) — */
+  .lamp {
+    animation: lamp-breathe 4.5s ease-in-out infinite alternate;
+  }
+
+  @keyframes lamp-breathe {
+    from {
+      opacity: 0.65;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  /* — Runway approach lights: a slow chase down the strip — */
+  .strip-lights rect {
+    animation: strip-chase 2.45s linear infinite;
+  }
+
+  .strip-lights rect:nth-child(1) { animation-delay: 0s; }
+  .strip-lights rect:nth-child(2) { animation-delay: 0.35s; }
+  .strip-lights rect:nth-child(3) { animation-delay: 0.7s; }
+  .strip-lights rect:nth-child(4) { animation-delay: 1.05s; }
+  .strip-lights rect:nth-child(5) { animation-delay: 1.4s; }
+  .strip-lights rect:nth-child(6) { animation-delay: 1.75s; }
+  .strip-lights rect:nth-child(7) { animation-delay: 2.1s; }
+
+  @keyframes strip-chase {
+    0%,
+    58% {
+      opacity: 0.35;
+    }
+    66% {
+      opacity: 1;
+    }
+    76%,
+    100% {
+      opacity: 0.35;
+    }
+  }
+
+  /* — Laguna shimmer — */
+  .laguna {
+    animation: laguna-shimmer 7s ease-in-out infinite alternate;
+  }
+
+  @keyframes laguna-shimmer {
+    from {
+      opacity: 0.86;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  /* — Rail icons lean into the hover — */
+  .rail-card .rail-icon {
+    transition: transform 200ms var(--ease-out);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .rail-card:hover .rail-icon {
+      transform: translateY(-2px) scale(1.06);
+    }
+
+    /* — One indulgence: light sweeps across the gold CTA — */
+    .btn.gold::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: -45%;
+      width: 38%;
+      background: linear-gradient(
+        105deg,
+        transparent,
+        color-mix(in oklab, white 55%, transparent),
+        transparent
+      );
+      transform: skewX(-18deg);
+      pointer-events: none;
+    }
+
+    .btn.gold:hover::after {
+      animation: gold-shine 900ms var(--ease-out);
+    }
+
+    @keyframes gold-shine {
+      to {
+        transform: skewX(-18deg) translateX(420%);
+      }
+    }
+  }
+
+  /* — Scroll choreography (progressive enhancement) — */
+  @supports (animation-timeline: scroll()) {
+    /* hero parallax: near layers exit faster, content recedes like a
+       camera pulling up and away */
+    .cine-hero .ridge-far,
+    .cine-hero .ridge-mid,
+    .cine-hero .ridge-near,
+    .cine-hero .terrace {
+      animation: linear both;
+      animation-timeline: scroll(root);
+      animation-range: 0 90vh;
+    }
+
+    .cine-hero .ridge-far {
+      animation-name: par-far;
+    }
+    .cine-hero .ridge-mid {
+      animation-name: par-mid;
+    }
+    .cine-hero .ridge-near {
+      animation-name: par-near;
+    }
+    .cine-hero .terrace {
+      animation-name: par-terrace;
+    }
+
+    @keyframes par-far {
+      to {
+        transform: translateY(-10px);
+      }
+    }
+    @keyframes par-mid {
+      to {
+        transform: translateY(-26px);
+      }
+    }
+    @keyframes par-near {
+      to {
+        transform: translateY(-46px);
+      }
+    }
+    @keyframes par-terrace {
+      to {
+        transform: translateY(-64px);
+      }
+    }
+
+    .cine-hero .cine-content {
+      animation: hero-recede linear both;
+      animation-timeline: scroll(root);
+      animation-range: 0 80vh;
+    }
+
+    @keyframes hero-recede {
+      to {
+        opacity: 0.3;
+        transform: translateY(34px);
+      }
+    }
+
+    /* sections rise as they enter the viewport */
+    .section-head {
+      animation: rise-in var(--ease-out) both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 80%;
+    }
+
+    .rail {
+      view-timeline: --rail block;
+    }
+
+    .rail-card {
+      animation: rise-in var(--ease-out) both;
+      animation-timeline: --rail;
+      animation-range: entry 0% entry 70%;
+    }
+
+    .rail-card:nth-child(2) { animation-range: entry 8% entry 78%; }
+    .rail-card:nth-child(3) { animation-range: entry 16% entry 86%; }
+    .rail-card:nth-child(4) { animation-range: entry 24% entry 94%; }
+    .rail-card:nth-child(5) { animation-range: entry 30% entry 100%; }
+    .rail-card:nth-child(6) { animation-range: entry 36% entry 100%; }
+
+    .flagship {
+      view-timeline: --flagship block;
+    }
+
+    .flagship-inner {
+      animation: rise-in var(--ease-out) both;
+      animation-timeline: --flagship;
+      animation-range: entry 20% entry 90%;
+    }
+
+    /* the fields plant themselves */
+    .crop-row {
+      stroke-dasharray: 1;
+      animation: crop-draw linear both;
+      animation-timeline: --flagship;
+      animation-range: entry 5% entry 60%;
+    }
+
+    .crop-row:nth-child(2) { animation-range: entry 13% entry 68%; }
+    .crop-row:nth-child(3) { animation-range: entry 21% entry 76%; }
+    .crop-row:nth-child(4) { animation-range: entry 29% entry 84%; }
+    .crop-row:nth-child(5) { animation-range: entry 37% entry 92%; }
+
+    @keyframes crop-draw {
+      from {
+        stroke-dashoffset: 1;
+      }
+      to {
+        stroke-dashoffset: 0;
+      }
+    }
+
+    .petal-strip {
+      view-timeline: --petals block;
+    }
+
+    .petal-strip .badge {
+      animation: rise-in var(--ease-out) both;
+      animation-timeline: --petals;
+      animation-range: entry 0% entry 100%;
+    }
+
+    .petal-strip .badge:nth-child(2) { animation-range: entry 6% entry 100%; }
+    .petal-strip .badge:nth-child(3) { animation-range: entry 12% entry 100%; }
+    .petal-strip .badge:nth-child(4) { animation-range: entry 18% entry 100%; }
+    .petal-strip .badge:nth-child(5) { animation-range: entry 24% entry 100%; }
+    .petal-strip .badge:nth-child(6) { animation-range: entry 30% entry 100%; }
+    .petal-strip .badge:nth-child(7) { animation-range: entry 36% entry 100%; }
+
+    @keyframes rise-in {
+      from {
+        opacity: 0;
+        transform: translateY(26px);
+      }
+    }
+  }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -463,6 +463,23 @@ label {
   align-items: flex-end;
   overflow: clip;
   border-radius: 0 0 calc(var(--radius) + 10px) calc(var(--radius) + 10px);
+  /* CSS sky — the base layer; the shader canvas paints over it when WebGL
+     is available, and this carries the scene when it isn't. */
+  background:
+    radial-gradient(
+      42% 58% at 72.2% 37.2%,
+      color-mix(in oklab, var(--sun) 55%, transparent) 0%,
+      transparent 70%
+    ),
+    linear-gradient(to bottom, var(--sky-hi) 0%, var(--sky-lo) 78%);
+}
+
+.shader-sky {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 
 .cine-hero .scene {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist, Geist_Mono, Fraunces } from 'next/font/google';
 import './globals.css';
 import { Nav } from '@/components/Nav';
 
@@ -13,10 +13,21 @@ const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
 });
 
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-fraunces',
+  axes: ['opsz'],
+  style: ['normal', 'italic'],
+});
+
 export const metadata: Metadata = {
   title: 'Ecologikal',
-  description: 'Eco + Social vertical — Certexi OS reference implementation',
+  description:
+    'La red regenerativa: flor de habilidades, KINS y eco-centros. Plataforma de Agroabundanza Institute.',
 };
+
+/* Applies the stored theme before first paint; system preference otherwise. */
+const themeInit = `try{var t=localStorage.getItem('eco-theme');if(t==='dark'||t==='light')document.documentElement.dataset.theme=t}catch(e){}`;
 
 export default function RootLayout({
   children,
@@ -24,7 +35,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="es" className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html
+      lang="es"
+      className={`${geistSans.variable} ${geistMono.variable} ${fraunces.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInit }} />
+      </head>
       <body>
         <div className="shell">
           <Nav />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,60 @@
 import Link from 'next/link';
 import { PETALS, PILLARS } from '@ecologikal/domain';
+import {
+  AirplaneTilt,
+  BookOpen,
+  Compass,
+  GameController,
+  Handshake,
+  UsersThree,
+} from '@phosphor-icons/react/ssr';
 import { SeedDemoButton } from '@/components/ClientForms';
+import { FlagshipScene, ValleScene } from '@/components/scenes';
 import { vintageUrl } from '@/lib/urls';
+
+const PILLAR_META: Record<
+  string,
+  {
+    Icon: React.ComponentType<{
+      size?: number;
+      weight?: 'duotone';
+      'aria-hidden'?: boolean;
+    }>;
+    tile: string;
+    tag: string;
+  }
+> = {
+  play: {
+    Icon: GameController,
+    tile: 'var(--gold)',
+    tag: 'Gana KINS con cada acción regenerativa.',
+  },
+  travel: {
+    Icon: AirplaneTilt,
+    tile: 'var(--blue)',
+    tag: 'Diarios de viaje colectivos entre eco-centros.',
+  },
+  discover: {
+    Icon: Compass,
+    tile: 'var(--green-bright)',
+    tag: 'Ecozonas y necesidades cerca de ti.',
+  },
+  learn: {
+    Icon: BookOpen,
+    tile: 'var(--pink)',
+    tag: 'Saber útil, filtrado por pétalo.',
+  },
+  meet: {
+    Icon: UsersThree,
+    tile: 'var(--green)',
+    tag: 'Econautas por lo que saben hacer.',
+  },
+  cooperate: {
+    Icon: Handshake,
+    tile: 'var(--gold)',
+    tag: 'Voluntariado experto con recompensa.',
+  },
+};
 
 export default function HomePage() {
   const vintage = vintageUrl('/');
@@ -11,54 +64,109 @@ export default function HomePage() {
 
   return (
     <main>
-      <section className="home-hero">
-        <p className="brand-mark">
-          Eco<em>logikal</em>
-        </p>
-        <p className="promise">
-          Tu flor de habilidades es tu reputación en la red regenerativa.
-        </p>
-        <p className="muted home-support">
-          Declara pétalos, gana KINS, y conoce econautas por lo que saben hacer.
-        </p>
-        <div className="row" style={{ marginTop: '1.5rem' }}>
-          <Link className="btn" href="/login">
-            Empezar mi flor
-          </Link>
-          <Link className="btn secondary" href="/meet">
-            Conoce
-          </Link>
-        </div>
-        <div className="pillars" style={{ marginTop: '1.25rem' }}>
-          {PILLARS.map((p) => (
-            <Link key={p.id} href={p.href}>
-              {p.labelEs}
-            </Link>
-          ))}
+      {/* ——— Cinematic opening ——— */}
+      <section className="cine-hero full-bleed" aria-label="Ecologikal">
+        <ValleScene />
+        <div className="cine-content">
+          <div className="cine-panel glass-panel">
+            <p className="kicker">La red regenerativa</p>
+            <p className="brand-mark">
+              Tu flor es tu <em>reputación</em>
+            </p>
+            <p className="promise">
+              Declara pétalos, gana KINS y encuentra tu lugar en la tierra que
+              estamos regenerando.
+            </p>
+            <div className="row" style={{ marginTop: '1.4rem' }}>
+              <Link className="btn" href="/login">
+                Empezar mi flor
+              </Link>
+              <Link className="btn secondary" href="/meet">
+                Conocer econautas
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
 
-      <section className="card" style={{ marginTop: '2rem' }}>
-        <h2>Siete pétalos</h2>
-        <div className="row" style={{ marginTop: '0.75rem' }}>
-          {PETALS.map((petal) => (
-            <span
-              key={petal.id}
-              className="badge"
-              style={{ borderColor: petal.color, color: petal.color }}
+      {/* ——— Six modes, one rail ——— */}
+      <div className="section-head">
+        <h2>Seis maneras de estar</h2>
+        <span className="muted" style={{ fontSize: '0.85rem' }}>
+          Modos de participación, no un feed
+        </span>
+      </div>
+      <div className="rail" role="list">
+        {PILLARS.map((p) => {
+          const meta = PILLAR_META[p.id];
+          const Icon = meta.Icon;
+          return (
+            <Link
+              key={p.id}
+              role="listitem"
+              href={p.href}
+              className="rail-card"
+              style={{ ['--tile' as string]: meta.tile }}
             >
-              {petal.id}. {petal.nameEs}
-            </span>
-          ))}
+              <div className="rail-icon">
+                <Icon size={26} weight="duotone" aria-hidden />
+              </div>
+              <h3>{p.labelEs}</h3>
+              <p>{meta.tag}</p>
+            </Link>
+          );
+        })}
+      </div>
+
+      {/* ——— Flagship center ——— */}
+      <section className="flagship" aria-label="Agroabundanza Institute">
+        <FlagshipScene />
+        <div className="flagship-inner glass-panel">
+          <p className="kicker">Centro insignia · 330 hectáreas</p>
+          <h2>Agroabundanza Institute</h2>
+          <p className="muted" style={{ margin: 0, fontSize: '0.95rem' }}>
+            Retiros donde se trabaja en problemas reales: agroecología,
+            educación vivencial e innovación para la abundancia sustentable.
+          </p>
+          <ul className="principles">
+            <li>Regenerar</li>
+            <li>Educar</li>
+            <li>Elevar</li>
+          </ul>
+          <div className="row">
+            <Link className="btn gold" href="/cooperate">
+              Ver retiros y vacantes
+            </Link>
+            <Link className="btn secondary" href="/travel">
+              Planear visita
+            </Link>
+          </div>
         </div>
       </section>
+
+      {/* ——— Petal taxonomy ——— */}
+      <div className="section-head">
+        <h2>Siete pétalos</h2>
+        <span className="muted" style={{ fontSize: '0.85rem' }}>
+          Una sola taxonomía para todo
+        </span>
+      </div>
+      <div className="petal-strip">
+        {PETALS.map((petal) => (
+          <span
+            key={petal.id}
+            className="badge"
+            style={{ borderColor: petal.color, color: petal.color }}
+          >
+            {petal.id}. {petal.nameEs}
+          </span>
+        ))}
+      </div>
 
       {allowDev ? (
         <section className="card home-dev">
           <h2>Desarrollo</h2>
-          <p className="muted">
-            Dual-stack y semillas — solo con flags de demo.
-          </p>
+          <p className="muted">Dual-stack y semillas — solo con flags de demo.</p>
           <div className="row" style={{ marginTop: '0.75rem' }}>
             <a className="btn secondary" href={vintage}>
               Vintage PHP

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -114,14 +114,13 @@ export default function HomePage() {
           Modos de participación, no un feed
         </span>
       </div>
-      <div className="rail" role="list">
+      <div className="rail">
         {PILLARS.map((p) => {
           const meta = PILLAR_META[p.id];
           const Icon = meta.Icon;
           return (
             <Link
               key={p.id}
-              role="listitem"
               href={p.href}
               className="rail-card"
               style={{ ['--tile' as string]: meta.tile }}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@phosphor-icons/react/ssr';
 import { SeedDemoButton } from '@/components/ClientForms';
 import { FlagshipScene, ValleScene } from '@/components/scenes';
+import { ShaderSky } from '@/components/ShaderSky';
 import { vintageUrl } from '@/lib/urls';
 
 const PILLAR_META: Record<
@@ -66,7 +67,8 @@ export default function HomePage() {
     <main>
       {/* ——— Cinematic opening ——— */}
       <section className="cine-hero full-bleed" aria-label="Ecologikal">
-        <ValleScene />
+        <ShaderSky />
+        <ValleScene hideSky />
         <div className="cine-content">
           <div className="cine-panel glass-panel">
             <p className="kicker">La red regenerativa</p>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -71,15 +71,31 @@ export default function HomePage() {
         <ValleScene hideSky />
         <div className="cine-content">
           <div className="cine-panel glass-panel">
-            <p className="kicker">La red regenerativa</p>
-            <p className="brand-mark">
-              Tu flor es tu <em>reputación</em>
+            <p className="kicker hero-rise" style={{ ['--i' as string]: 0 }}>
+              La red regenerativa
             </p>
-            <p className="promise">
+            <p className="brand-mark">
+              {['Tu', 'flor', 'es', 'tu'].map((word, i) => (
+                <span
+                  key={word + i}
+                  className="hero-word"
+                  style={{ ['--i' as string]: i + 1 }}
+                >
+                  {word}
+                </span>
+              ))}
+              <em className="hero-word" style={{ ['--i' as string]: 5 }}>
+                reputación
+              </em>
+            </p>
+            <p className="promise hero-rise" style={{ ['--i' as string]: 6 }}>
               Declara pétalos, gana KINS y encuentra tu lugar en la tierra que
               estamos regenerando.
             </p>
-            <div className="row" style={{ marginTop: '1.4rem' }}>
+            <div
+              className="row hero-rise"
+              style={{ marginTop: '1.4rem', ['--i' as string]: 7 }}
+            >
               <Link className="btn" href="/login">
                 Empezar mi flor
               </Link>

--- a/apps/web/components/Nav.tsx
+++ b/apps/web/components/Nav.tsx
@@ -10,6 +10,7 @@ import {
 } from '@phosphor-icons/react/ssr';
 import { getSession } from '@/lib/auth';
 import { vintageUrl } from '@/lib/urls';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 const PILLAR_ICONS: Record<
   string,
@@ -51,6 +52,7 @@ export async function Nav() {
         })}
       </nav>
       <div className="row">
+        <ThemeToggle />
         <a className="btn secondary" href={vintage} title="Vintage PHP UI">
           Vintage
         </a>

--- a/apps/web/components/ShaderSky.tsx
+++ b/apps/web/components/ShaderSky.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Live shader sky for the landing hero. Raw WebGL1 (no dependency): a slow
+ * atmospheric gradient with drifting fbm haze and a breathing sun, colored at
+ * runtime from the theme tokens so dark/light both render correctly.
+ *
+ * Craft constraints (emil-design-eng):
+ * - GPU-only work; DPR capped at 1.5; loop pauses when the hero leaves the
+ *   viewport (IntersectionObserver) and when the tab is hidden (rAF).
+ * - prefers-reduced-motion: a single still frame, redrawn only on theme change.
+ * - If WebGL is unavailable the canvas stays empty and the CSS-gradient sky
+ *   behind it (on .cine-hero) carries the scene — no JS fallback needed.
+ */
+
+const FRAG = `
+precision mediump float;
+uniform vec2 u_res;
+uniform float u_t;
+uniform vec3 u_skyHi;
+uniform vec3 u_skyLo;
+uniform vec3 u_sun;
+uniform vec3 u_haze;
+
+float hash(vec2 p) {
+  return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float noise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * (3.0 - 2.0 * f);
+  return mix(
+    mix(hash(i), hash(i + vec2(1.0, 0.0)), u.x),
+    mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), u.x),
+    u.y
+  );
+}
+
+float fbm(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 4; i++) {
+    v += a * noise(p);
+    p = p * 2.03 + vec2(11.3, 7.9);
+    a *= 0.5;
+  }
+  return v;
+}
+
+void main() {
+  vec2 st = gl_FragCoord.xy / u_res; /* y up */
+  float aspect = u_res.x / u_res.y;
+
+  /* base sky: horizon glow rises into the upper sky */
+  vec3 col = mix(u_skyLo, u_skyHi, smoothstep(0.15, 0.95, st.y));
+
+  /* drifting haze, heavier near the horizon */
+  float h = fbm(vec2(st.x * 3.0 + u_t * 0.016, st.y * 5.0 + u_t * 0.004));
+  float band = smoothstep(0.75, 0.2, st.y);
+  col = mix(col, u_haze, h * band * 0.35);
+
+  /* thin high cloud drift */
+  float c = fbm(vec2(st.x * 6.0 - u_t * 0.01, st.y * 14.0));
+  col = mix(col, u_haze, smoothstep(0.55, 0.85, c) * (1.0 - band) * 0.12);
+
+  /* sun — position matches the vector scene (72% across, 37% down) */
+  vec2 sun = vec2(0.722, 0.628);
+  vec2 d2 = st - sun;
+  d2.x *= aspect;
+  float d = length(d2);
+  float breathe = 1.0 + 0.05 * sin(u_t * 0.25);
+  float glow = exp(-d * 5.5) * 0.45 + exp(-d * 16.0) * 0.4;
+  col += u_sun * glow * breathe;
+  col = mix(col, u_sun, smoothstep(0.052, 0.046, d));
+
+  /* dither to kill gradient banding */
+  col += (hash(gl_FragCoord.xy) - 0.5) * (1.8 / 255.0);
+
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+const VERT = `
+attribute vec2 a_pos;
+void main() { gl_Position = vec4(a_pos, 0.0, 1.0); }
+`;
+
+/** Resolve a CSS color (incl. oklch) to 0..1 RGB via 2D-canvas readback. */
+function makeColorResolver() {
+  const c = document.createElement('canvas');
+  c.width = c.height = 1;
+  const ctx = c.getContext('2d', { willReadFrequently: true });
+  return (color: string): [number, number, number] => {
+    if (!ctx) return [0, 0, 0];
+    ctx.fillStyle = '#000';
+    ctx.fillStyle = color.trim();
+    ctx.fillRect(0, 0, 1, 1);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0] / 255, d[1] / 255, d[2] / 255];
+  };
+}
+
+export function ShaderSky() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const gl = canvas.getContext('webgl', {
+      alpha: false,
+      antialias: false,
+      powerPreference: 'low-power',
+    });
+    if (!gl) return; /* CSS sky behind us carries the scene */
+
+    const compile = (type: number, src: string) => {
+      const s = gl.createShader(type);
+      if (!s) return null;
+      gl.shaderSource(s, src);
+      gl.compileShader(s);
+      if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+        gl.deleteShader(s);
+        return null;
+      }
+      return s;
+    };
+
+    const vs = compile(gl.VERTEX_SHADER, VERT);
+    const fs = compile(gl.FRAGMENT_SHADER, FRAG);
+    if (!vs || !fs) return;
+    const prog = gl.createProgram();
+    if (!prog) return;
+    gl.attachShader(prog, vs);
+    gl.attachShader(prog, fs);
+    gl.linkProgram(prog);
+    if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return;
+    gl.useProgram(prog);
+
+    const quad = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, quad);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW,
+    );
+    const aPos = gl.getAttribLocation(prog, 'a_pos');
+    gl.enableVertexAttribArray(aPos);
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0);
+
+    const uRes = gl.getUniformLocation(prog, 'u_res');
+    const uT = gl.getUniformLocation(prog, 'u_t');
+    const uSkyHi = gl.getUniformLocation(prog, 'u_skyHi');
+    const uSkyLo = gl.getUniformLocation(prog, 'u_skyLo');
+    const uSun = gl.getUniformLocation(prog, 'u_sun');
+    const uHaze = gl.getUniformLocation(prog, 'u_haze');
+
+    const resolve = makeColorResolver();
+    const readTheme = () => {
+      const cs = getComputedStyle(document.documentElement);
+      gl.uniform3fv(uSkyHi, resolve(cs.getPropertyValue('--sky-hi')));
+      gl.uniform3fv(uSkyLo, resolve(cs.getPropertyValue('--sky-lo')));
+      gl.uniform3fv(uSun, resolve(cs.getPropertyValue('--sun')));
+      gl.uniform3fv(uHaze, resolve(cs.getPropertyValue('--haze')));
+    };
+    readTheme();
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    const resize = () => {
+      const w = Math.max(1, Math.round(canvas.clientWidth * dpr));
+      const h = Math.max(1, Math.round(canvas.clientHeight * dpr));
+      if (canvas.width !== w || canvas.height !== h) {
+        canvas.width = w;
+        canvas.height = h;
+        gl.viewport(0, 0, w, h);
+      }
+      gl.uniform2f(uRes, canvas.width, canvas.height);
+    };
+    resize();
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const start = performance.now();
+    let raf = 0;
+    let visible = true;
+
+    const draw = (t: number) => {
+      gl.uniform1f(uT, t);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const loop = () => {
+      draw((performance.now() - start) / 1000);
+      raf = requestAnimationFrame(loop);
+    };
+
+    const still = () => {
+      resize();
+      draw(40); /* a pleasant fixed moment of drift */
+    };
+
+    const run = () => {
+      cancelAnimationFrame(raf);
+      if (reduced.matches) still();
+      else if (visible) raf = requestAnimationFrame(loop);
+    };
+    run();
+
+    const ro = new ResizeObserver(() => {
+      resize();
+      if (reduced.matches) still();
+    });
+    ro.observe(canvas);
+
+    const io = new IntersectionObserver(([e]) => {
+      visible = e.isIntersecting;
+      run();
+    });
+    io.observe(canvas);
+
+    const mo = new MutationObserver(() => {
+      readTheme();
+      if (reduced.matches) still();
+    });
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    const scheme = window.matchMedia('(prefers-color-scheme: dark)');
+    const onScheme = () => {
+      readTheme();
+      if (reduced.matches) still();
+    };
+    scheme.addEventListener('change', onScheme);
+    reduced.addEventListener('change', run);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      io.disconnect();
+      mo.disconnect();
+      scheme.removeEventListener('change', onScheme);
+      reduced.removeEventListener('change', run);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="shader-sky" aria-hidden="true" />;
+}

--- a/apps/web/components/ShaderSky.tsx
+++ b/apps/web/components/ShaderSky.tsx
@@ -236,7 +236,17 @@ export function ShaderSky() {
     scheme.addEventListener('change', onScheme);
     reduced.addEventListener('change', run);
 
+    /* If the GPU context is lost, hide the canvas so the CSS sky beneath
+       carries the scene instead of a dead black rectangle. */
+    const onLost = (e: Event) => {
+      e.preventDefault();
+      cancelAnimationFrame(raf);
+      canvas.style.display = 'none';
+    };
+    canvas.addEventListener('webglcontextlost', onLost);
+
     return () => {
+      canvas.removeEventListener('webglcontextlost', onLost);
       cancelAnimationFrame(raf);
       ro.disconnect();
       io.disconnect();

--- a/apps/web/components/ThemeToggle.tsx
+++ b/apps/web/components/ThemeToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Moon, Sun } from '@phosphor-icons/react';
+
+type Theme = 'dark' | 'light';
+
+function systemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
+/**
+ * Dark ↔ light toggle. The pre-hydration script in layout.tsx applies the
+ * stored choice before first paint; this button only flips + persists it.
+ */
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme | null>(null);
+
+  useEffect(() => {
+    const stored = document.documentElement.dataset.theme;
+    setTheme(stored === 'dark' || stored === 'light' ? stored : systemTheme());
+  }, []);
+
+  const toggle = useCallback(() => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem('eco-theme', next);
+    } catch {
+      /* private mode — theme still applies for this page */
+    }
+    setTheme(next);
+  }, [theme]);
+
+  // Render a stable placeholder pre-hydration to avoid icon flicker.
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggle}
+      aria-label={
+        theme === 'dark' ? 'Cambiar a modo día' : 'Cambiar a modo noche'
+      }
+      title={theme === 'dark' ? 'Modo día' : 'Modo noche'}
+    >
+      {theme === 'dark' ? (
+        <Sun size={15} weight="bold" aria-hidden />
+      ) : (
+        <Moon size={15} weight="bold" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/apps/web/components/scenes.tsx
+++ b/apps/web/components/scenes.tsx
@@ -4,8 +4,12 @@
  * morning gold in light mode. Decorative: aria-hidden, no external assets.
  */
 
-/** Valle hero — low sun over layered ridges and terraced fields. */
-export function ValleScene() {
+/**
+ * Valle hero — low sun over layered ridges and terraced fields.
+ * With `hideSky`, the sky rect and sun are omitted so a live layer behind
+ * (ShaderSky, or the .cine-hero CSS gradient) paints them instead.
+ */
+export function ValleScene({ hideSky = false }: { hideSky?: boolean }) {
   return (
     <div className="scene" aria-hidden="true">
       <svg
@@ -28,10 +32,14 @@ export function ValleScene() {
           </linearGradient>
         </defs>
 
-        {/* sky + sun */}
-        <rect width="1440" height="640" fill="url(#vs-sky)" />
-        <circle cx="1040" cy="238" r="210" fill="url(#vs-glow)" />
-        <circle cx="1040" cy="238" r="46" fill="var(--sun)" />
+        {/* sky + sun — omitted when a live sky renders behind the svg */}
+        {hideSky ? null : (
+          <>
+            <rect width="1440" height="640" fill="url(#vs-sky)" />
+            <circle cx="1040" cy="238" r="210" fill="url(#vs-glow)" />
+            <circle cx="1040" cy="238" r="46" fill="var(--sun)" />
+          </>
+        )}
 
         {/* far ridge */}
         <path

--- a/apps/web/components/scenes.tsx
+++ b/apps/web/components/scenes.tsx
@@ -43,6 +43,7 @@ export function ValleScene({ hideSky = false }: { hideSky?: boolean }) {
 
         {/* far ridge */}
         <path
+          className="ridge-far"
           d="M0 300 C 180 258, 340 292, 520 274 C 700 256, 830 296, 1010 282 C 1190 268, 1320 296, 1440 278 L 1440 640 L 0 640 Z"
           fill="var(--ridge-far)"
         />
@@ -50,26 +51,31 @@ export function ValleScene({ hideSky = false }: { hideSky?: boolean }) {
 
         {/* mid ridge */}
         <path
+          className="ridge-mid"
           d="M0 384 C 210 342, 380 388, 560 368 C 760 346, 900 396, 1090 378 C 1260 362, 1360 388, 1440 374 L 1440 640 L 0 640 Z"
           fill="var(--ridge-mid)"
         />
 
         {/* near ridge */}
         <path
+          className="ridge-near"
           d="M0 462 C 190 428, 400 470, 610 452 C 830 432, 1010 476, 1210 458 C 1320 448, 1390 462, 1440 456 L 1440 640 L 0 640 Z"
           fill="var(--ridge-near)"
         />
 
         {/* terraced foreground */}
-        <path d="M0 520 C 320 492, 760 540, 1440 508 L 1440 640 L 0 640 Z" fill="var(--field)" />
-        <g stroke="var(--field-row)" strokeWidth="6" fill="none" opacity="0.75">
-          <path d="M-30 552 C 330 522, 750 566, 1470 536" />
-          <path d="M-30 584 C 330 556, 750 598, 1470 566" />
-          <path d="M-30 616 C 330 590, 750 630, 1470 598" />
+        <g className="terrace">
+          <path d="M0 520 C 320 492, 760 540, 1440 508 L 1440 640 L 0 640 Z" fill="var(--field)" />
+          <g stroke="var(--field-row)" strokeWidth="6" fill="none" opacity="0.75">
+            <path d="M-30 552 C 330 522, 750 566, 1470 536" />
+            <path d="M-30 584 C 330 556, 750 598, 1470 566" />
+            <path d="M-30 616 C 330 590, 750 630, 1470 598" />
+          </g>
         </g>
 
         {/* birds */}
         <g
+          className="birds"
           stroke="var(--ink)"
           strokeWidth="2.5"
           strokeLinecap="round"
@@ -123,17 +129,17 @@ export function FlagshipScene() {
 
         {/* curved crop rows */}
         <g stroke="var(--field-row)" strokeWidth="9" fill="none" opacity="0.85">
-          <path d="M120 430 C 240 330, 250 220, 160 110" />
-          <path d="M170 442 C 300 336, 312 212, 210 92" />
-          <path d="M224 452 C 360 342, 374 206, 262 78" />
-          <path d="M282 458 C 420 348, 436 202, 318 68" />
-          <path d="M344 462 C 480 354, 498 200, 378 62" />
+          <path className="crop-row" pathLength={1} d="M120 430 C 240 330, 250 220, 160 110" />
+          <path className="crop-row" pathLength={1} d="M170 442 C 300 336, 312 212, 210 92" />
+          <path className="crop-row" pathLength={1} d="M224 452 C 360 342, 374 206, 262 78" />
+          <path className="crop-row" pathLength={1} d="M282 458 C 420 348, 436 202, 318 68" />
+          <path className="crop-row" pathLength={1} d="M344 462 C 480 354, 498 200, 378 62" />
         </g>
 
         {/* airstrip */}
         <g transform="rotate(-14 880 120)">
           <rect x="640" y="96" width="480" height="46" rx="10" fill="var(--ridge-mid)" />
-          <g fill="var(--haze)" opacity="0.85">
+          <g className="strip-lights" fill="var(--haze)" opacity="0.85">
             <rect x="668" y="116" width="34" height="6" rx="3" />
             <rect x="730" y="116" width="34" height="6" rx="3" />
             <rect x="792" y="116" width="34" height="6" rx="3" />
@@ -146,22 +152,23 @@ export function FlagshipScene() {
 
         {/* laguna */}
         <path
+          className="laguna"
           d="M760 320 C 800 288, 872 292, 908 320 C 944 348, 936 392, 892 406 C 844 420, 776 412, 752 380 C 734 356, 736 338, 760 320 Z"
           fill="var(--water)"
         />
 
         {/* campus — palapa circles, lit at dusk */}
         <g>
-          <circle cx="560" cy="250" r="60" fill="url(#fs-lamp)" />
+          <circle className="lamp" cx="560" cy="250" r="60" fill="url(#fs-lamp)" />
           <circle cx="560" cy="250" r="26" fill="var(--ridge-near)" />
           <circle cx="560" cy="250" r="26" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
-          <circle cx="648" cy="300" r="44" fill="url(#fs-lamp)" />
+          <circle className="lamp" style={{ animationDelay: '-1.6s' }} cx="648" cy="300" r="44" fill="url(#fs-lamp)" />
           <circle cx="648" cy="300" r="18" fill="var(--ridge-near)" />
           <circle cx="648" cy="300" r="18" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
-          <circle cx="620" cy="188" r="40" fill="url(#fs-lamp)" />
+          <circle className="lamp" style={{ animationDelay: '-3.1s' }} cx="620" cy="188" r="40" fill="url(#fs-lamp)" />
           <circle cx="620" cy="188" r="15" fill="var(--ridge-near)" />
           <circle cx="620" cy="188" r="15" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
-          <circle cx="700" cy="232" r="34" fill="url(#fs-lamp)" />
+          <circle className="lamp" style={{ animationDelay: '-2.2s' }} cx="700" cy="232" r="34" fill="url(#fs-lamp)" />
           <circle cx="700" cy="232" r="12" fill="var(--ridge-near)" />
           <circle cx="700" cy="232" r="12" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
         </g>

--- a/apps/web/components/scenes.tsx
+++ b/apps/web/components/scenes.tsx
@@ -1,0 +1,174 @@
+/**
+ * Cinematic inline-SVG scenes. Every color is a CSS custom property from
+ * globals.css, so the same geometry renders as amber dusk in dark mode and
+ * morning gold in light mode. Decorative: aria-hidden, no external assets.
+ */
+
+/** Valle hero — low sun over layered ridges and terraced fields. */
+export function ValleScene() {
+  return (
+    <div className="scene" aria-hidden="true">
+      <svg
+        viewBox="0 0 1440 640"
+        preserveAspectRatio="xMidYMax slice"
+        role="presentation"
+      >
+        <defs>
+          <linearGradient id="vs-sky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="var(--sky-hi)" />
+            <stop offset="1" stopColor="var(--sky-lo)" />
+          </linearGradient>
+          <radialGradient id="vs-glow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stopColor="var(--sun)" stopOpacity="0.55" />
+            <stop offset="1" stopColor="var(--sun)" stopOpacity="0" />
+          </radialGradient>
+          <linearGradient id="vs-haze" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="var(--haze)" stopOpacity="0" />
+            <stop offset="1" stopColor="var(--haze)" stopOpacity="0.55" />
+          </linearGradient>
+        </defs>
+
+        {/* sky + sun */}
+        <rect width="1440" height="640" fill="url(#vs-sky)" />
+        <circle cx="1040" cy="238" r="210" fill="url(#vs-glow)" />
+        <circle cx="1040" cy="238" r="46" fill="var(--sun)" />
+
+        {/* far ridge */}
+        <path
+          d="M0 300 C 180 258, 340 292, 520 274 C 700 256, 830 296, 1010 282 C 1190 268, 1320 296, 1440 278 L 1440 640 L 0 640 Z"
+          fill="var(--ridge-far)"
+        />
+        <rect y="240" width="1440" height="140" fill="url(#vs-haze)" />
+
+        {/* mid ridge */}
+        <path
+          d="M0 384 C 210 342, 380 388, 560 368 C 760 346, 900 396, 1090 378 C 1260 362, 1360 388, 1440 374 L 1440 640 L 0 640 Z"
+          fill="var(--ridge-mid)"
+        />
+
+        {/* near ridge */}
+        <path
+          d="M0 462 C 190 428, 400 470, 610 452 C 830 432, 1010 476, 1210 458 C 1320 448, 1390 462, 1440 456 L 1440 640 L 0 640 Z"
+          fill="var(--ridge-near)"
+        />
+
+        {/* terraced foreground */}
+        <path d="M0 520 C 320 492, 760 540, 1440 508 L 1440 640 L 0 640 Z" fill="var(--field)" />
+        <g stroke="var(--field-row)" strokeWidth="6" fill="none" opacity="0.75">
+          <path d="M-30 552 C 330 522, 750 566, 1470 536" />
+          <path d="M-30 584 C 330 556, 750 598, 1470 566" />
+          <path d="M-30 616 C 330 590, 750 630, 1470 598" />
+        </g>
+
+        {/* birds */}
+        <g
+          stroke="var(--ink)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          fill="none"
+          opacity="0.5"
+        >
+          <path d="M690 186 q 9 -9 18 0 q 9 -9 18 0" />
+          <path d="M760 158 q 7 -7 14 0 q 7 -7 14 0" />
+          <path d="M820 200 q 6 -6 12 0 q 6 -6 12 0" />
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+/** Flagship aerial — curved crop rows, laguna, airstrip, campus lights. */
+export function FlagshipScene() {
+  return (
+    <div className="scene" aria-hidden="true">
+      <svg
+        viewBox="0 0 1200 480"
+        preserveAspectRatio="xMidYMid slice"
+        role="presentation"
+      >
+        <defs>
+          <linearGradient id="fs-light" x1="1" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="var(--sun)" stopOpacity="0.28" />
+            <stop offset="0.55" stopColor="var(--sun)" stopOpacity="0" />
+          </linearGradient>
+          <radialGradient id="fs-lamp" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stopColor="var(--sun)" stopOpacity="0.9" />
+            <stop offset="1" stopColor="var(--sun)" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        {/* land */}
+        <rect width="1200" height="480" fill="var(--field)" />
+
+        {/* bamboo perimeter */}
+        <rect
+          x="14"
+          y="14"
+          width="1172"
+          height="452"
+          rx="60"
+          fill="none"
+          stroke="var(--ridge-near)"
+          strokeWidth="30"
+          opacity="0.85"
+        />
+
+        {/* curved crop rows */}
+        <g stroke="var(--field-row)" strokeWidth="9" fill="none" opacity="0.85">
+          <path d="M120 430 C 240 330, 250 220, 160 110" />
+          <path d="M170 442 C 300 336, 312 212, 210 92" />
+          <path d="M224 452 C 360 342, 374 206, 262 78" />
+          <path d="M282 458 C 420 348, 436 202, 318 68" />
+          <path d="M344 462 C 480 354, 498 200, 378 62" />
+        </g>
+
+        {/* airstrip */}
+        <g transform="rotate(-14 880 120)">
+          <rect x="640" y="96" width="480" height="46" rx="10" fill="var(--ridge-mid)" />
+          <g fill="var(--haze)" opacity="0.85">
+            <rect x="668" y="116" width="34" height="6" rx="3" />
+            <rect x="730" y="116" width="34" height="6" rx="3" />
+            <rect x="792" y="116" width="34" height="6" rx="3" />
+            <rect x="854" y="116" width="34" height="6" rx="3" />
+            <rect x="916" y="116" width="34" height="6" rx="3" />
+            <rect x="978" y="116" width="34" height="6" rx="3" />
+            <rect x="1040" y="116" width="34" height="6" rx="3" />
+          </g>
+        </g>
+
+        {/* laguna */}
+        <path
+          d="M760 320 C 800 288, 872 292, 908 320 C 944 348, 936 392, 892 406 C 844 420, 776 412, 752 380 C 734 356, 736 338, 760 320 Z"
+          fill="var(--water)"
+        />
+
+        {/* campus — palapa circles, lit at dusk */}
+        <g>
+          <circle cx="560" cy="250" r="60" fill="url(#fs-lamp)" />
+          <circle cx="560" cy="250" r="26" fill="var(--ridge-near)" />
+          <circle cx="560" cy="250" r="26" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
+          <circle cx="648" cy="300" r="44" fill="url(#fs-lamp)" />
+          <circle cx="648" cy="300" r="18" fill="var(--ridge-near)" />
+          <circle cx="648" cy="300" r="18" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
+          <circle cx="620" cy="188" r="40" fill="url(#fs-lamp)" />
+          <circle cx="620" cy="188" r="15" fill="var(--ridge-near)" />
+          <circle cx="620" cy="188" r="15" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
+          <circle cx="700" cy="232" r="34" fill="url(#fs-lamp)" />
+          <circle cx="700" cy="232" r="12" fill="var(--ridge-near)" />
+          <circle cx="700" cy="232" r="12" fill="none" stroke="var(--sun)" strokeWidth="3" opacity="0.9" />
+        </g>
+
+        {/* connecting paths */}
+        <g stroke="var(--haze)" strokeWidth="5" fill="none" opacity="0.5" strokeLinecap="round">
+          <path d="M560 276 C 580 300, 610 306, 630 302" />
+          <path d="M588 238 C 600 220, 610 206, 618 200" />
+          <path d="M666 288 C 680 268, 690 250, 696 244" />
+          <path d="M676 310 C 710 330, 744 344, 766 352" />
+        </g>
+
+        {/* dusk light wash */}
+        <rect width="1200" height="480" fill="url(#fs-light)" />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The visual platform layer for Agroabundanza Institute's mission on Ecologikal: a cinematic, glassmorphic dual-theme system plus a rebuilt Netflix-style home.

- **Dual theme** (OKLCH tokens): dark "dusk at the center" default-by-system, light "daylight in the field"; toggle in nav persists via localStorage, applied pre-hydration (no FOUC).
- **Clear glass, purposeful**: floating nav pill, hero and flagship panels only — backdrop blur + hairline + inner highlight, `@supports` fallback. Solid surfaces elsewhere.
- **Crafted imagery, zero assets**: theme-aware inline SVG scenes — Valle hero (low sun, layered ridges, terraces, birds) and Agroabundanza aerial (curved crop rows, laguna, airstrip, lit palapa campus) + subtle film grain.
- **Type**: Fraunces display serif (modest luxury) over Geist; gold kicker thread.
- **Home**: full-bleed cinematic hero, six-pillar scroll-snap rail, flagship Agroabundanza section (Regenerar · Educar · Elevar), petal strip.
- **Craft fixes**: removed legacy side-stripe borders; mobile nav returns to flow; `overflow-x: clip`; reduced-motion and hover-capability guards throughout.
- PRODUCT.md + DESIGN.md added (impeccable context), demo seed center renamed to Agroabundanza Institute.

## Verification

- Browser-verified on desktop + mobile, dark + light, reload persistence — screenshots in session.
- Zero console errors; `pnpm typecheck` green across workspace; invariant gate passed (pre-commit/pre-push hooks ran live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)